### PR TITLE
AKS install/upgrade smoke harness and chart overlays (#10)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,16 @@ jobs:
         run: |
           helm template honua-stage ./honua -f honua/values-stage.yaml --is-upgrade > /tmp/honua-rendered-stage-upgrade.yaml
 
+      - name: Lint AKS smoke overlays
+        run: |
+          helm lint honua -f honua/ci-values/aks-smoke-install.yaml
+          helm lint honua -f honua/ci-values/aks-smoke-upgrade.yaml
+
+      - name: Render AKS smoke overlays (install + upgrade path)
+        run: |
+          helm template honua ./honua -f honua/ci-values/aks-smoke-install.yaml > /tmp/honua-rendered-aks-install.yaml
+          helm template honua ./honua --is-upgrade -f honua/ci-values/aks-smoke-upgrade.yaml > /tmp/honua-rendered-aks-upgrade.yaml
+
       - name: Render templates (ingress hosts empty)
         run: helm template honua ./honua -f honua/ci-values/ingress-empty.yaml > /tmp/honua-rendered-ingress-empty.yaml
 
@@ -121,6 +131,22 @@ jobs:
           grep -A1 'name: HONUA_PREFLIGHT_DATABASE_CHECK' /tmp/honua-rendered-base.yaml | grep -q 'value: "true"'
           grep -A1 'name: HONUA_PREFLIGHT_DATABASE_CHECK' /tmp/honua-rendered-postgresql-install.yaml | grep -q 'value: "false"'
           grep -A1 'name: HONUA_PREFLIGHT_DATABASE_CHECK' /tmp/honua-rendered-postgresql-upgrade.yaml | grep -q 'value: "true"'
+
+      - name: Assert AKS smoke overlay operator contract
+        run: |
+          set -euo pipefail
+
+          # AKS install overlay must render the migration-safe contract surfaces.
+          grep -q 'name: honua-honua-preflight' /tmp/honua-rendered-aks-install.yaml
+          grep -q 'name: honua-honua-release-info' /tmp/honua-rendered-aks-install.yaml
+          grep -q 'type: Recreate' /tmp/honua-rendered-aks-install.yaml
+          grep -q 'honua.io/release-id: "honua-aks-smoke-install"' /tmp/honua-rendered-aks-install.yaml
+          # External managed data services: no chart-managed PostgreSQL/Redis subcharts.
+          if grep -q 'name: honua-postgresql' /tmp/honua-rendered-aks-install.yaml; then
+            echo "AKS install overlay must not render the chart-managed PostgreSQL subchart."
+            exit 1
+          fi
+          grep -q 'honua.io/release-id: "honua-aks-smoke-upgrade"' /tmp/honua-rendered-aks-upgrade.yaml
 
       - name: Validate autoscaling guard fails invalid config
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 # Helm dependency packages (generated)
 /honua/charts/
+
+# AKS smoke evidence output (scripts/aks-smoke.sh default --evidence-dir)
+/evidence/

--- a/docs/smoke/aks-chart-smoke.md
+++ b/docs/smoke/aks-chart-smoke.md
@@ -1,0 +1,115 @@
+# AKS Chart Smoke Runbook (honua-helm#10)
+
+This runbook covers the **AKS-specific** install + upgrade smoke for the Honua
+Helm chart, on the Azure Marketplace customer-operated deployment path. It is
+the AKS-specific tracker referenced by
+`honua-sales/docs/user/AZURE_MARKETPLACE_DEPLOYMENT_PATH.md`.
+
+The generic cross-provider install/upgrade/rollback smoke runs in CI on `kind`
+(`.github/workflows/ci.yml`, job `install-upgrade-rollback-smoke`). This runbook
+is the AKS overlay of that contract: the same chart, validated against a real
+AKS cluster so the marketplace listing does not publish on ambiguous Kubernetes
+evidence.
+
+## What is automated here
+
+- `honua/ci-values/aks-smoke-install.yaml` — install baseline for the
+  customer-operated AKS path (external PostGIS + Redis, pre-created runtime
+  Secret, migration-safe `Recreate` strategy, preflight + registry check on).
+- `honua/ci-values/aks-smoke-upgrade.yaml` — upgrade target overlay applied as
+  the `helm upgrade` step (scales replicas, rotates release evidence metadata).
+- `scripts/aks-smoke.sh` — the parameterized harness that runs install →
+  `helm test` → upgrade → `helm test` → rollback → `helm test`, then captures
+  the evidence the issue's acceptance criteria require. It supports a `--dry-run`
+  mode (render + lint + kubeconform, no cluster) that runs in CI so the AKS
+  overlays cannot rot.
+
+The harness does **not** provision AKS and does **not** fabricate results. Every
+recorded value comes from a command it actually ran against the kubeconfig you
+supply.
+
+## Prerequisites (operator)
+
+1. An AKS validation cluster matching the customer-operated path. Reuse the
+   `honua-terraform#2` validation cluster when it provisions AKS; otherwise
+   record the temporary AKS setup in the evidence directory.
+2. `az aks get-credentials ...` so `kubectl config current-context` points at
+   the AKS cluster.
+3. An external PostGIS database and Redis reachable from the cluster (Bitnami
+   PostgreSQL has no PostGIS; the overlays disable both subcharts).
+4. The runtime Secret in the target namespace, either pre-created or created by
+   the harness with `--create-runtime-secret` and the `HONUA_*` env inputs.
+
+## Run
+
+Dry-run first (no cluster), to validate overlays and the harness:
+
+```bash
+scripts/aks-smoke.sh --dry-run --image-tag <vX.Y.Z-aot>
+```
+
+Live AKS install + upgrade + rollback smoke:
+
+```bash
+export HONUA_DB_CONNECTION='Host=pg.example.com;Port=5432;Database=honua;Username=honua;Password=...'
+export HONUA_REDIS_CONNECTION='redis.example.com:6379,password=...'
+export HONUA_ADMIN_PASSWORD='...'        # >=16 chars, mixed case + digit + special
+export HONUA_MASTER_KEY='...'            # >=32 chars
+
+scripts/aks-smoke.sh \
+  --release honua \
+  --namespace honua \
+  --image-digest sha256:<64hex> \
+  --release-id <listing-release-id> \
+  --release-manifest <release-manifest-url> \
+  --release-digest sha256:<64hex> \
+  --create-runtime-secret \
+  --evidence-dir evidence/aks-<date>
+```
+
+Pin by digest for listing-submission evidence. Use `--image-tag` only for
+pre-submission validation. Secret material is passed via env vars and is never
+written to the evidence directory or the command log.
+
+## Acceptance-criteria mapping
+
+| Issue AC | Where it is satisfied |
+| --- | --- |
+| Clean AKS install smoke passes for the listing chart version | `helm install` step + post-install `helm test`; `helm-history.txt`, `healthcheck-install.log` |
+| Chart upgrade smoke passes against the same AKS path | `helm upgrade` step + post-upgrade `helm test`; `healthcheck-upgrade.log` |
+| Evidence records chart version | `summary.md`, `release-info.yaml` (`HONUA_CHART_VERSION`) |
+| Evidence records image digests | `image-ids.txt` (kubelet-resolved `imageID`), `release-info.yaml`, `summary.md` |
+| Evidence records values file / overlay | `summary.md` (overlay paths), `helm-values.txt` |
+| Evidence records cluster / runtime target | `summary.md` (kube-context), `nodes.txt`, `aks-node-labels.txt` |
+| Evidence records commands | `commands.log` (timestamped transcript) |
+| Evidence records health-check output | `healthcheck-{install,upgrade,rollback}.log`, `pod-readiness.txt` |
+| Failures owned by another repo are filed/linked there | Operator files in the owning repo; link back here |
+
+## Evidence directory layout
+
+```
+evidence/aks-<date>/
+  summary.md                    header + AC-mapped result
+  commands.log                  timestamped command transcript
+  nodes.txt, aks-node-labels.txt  cluster/runtime target
+  helm-history.txt              install/upgrade/rollback revisions
+  helm-notes.txt, helm-values.txt
+  release-info.yaml             chart/app version, image + release digests
+  workloads.txt, pod-readiness.txt, image-ids.txt
+  healthcheck-install.log
+  healthcheck-upgrade.log
+  healthcheck-rollback.log
+  events.txt
+```
+
+The default `evidence/` directory is gitignored. To retain a run as release
+evidence, copy the directory under a committed path or attach it to the issue.
+
+## Scope boundaries
+
+This smoke proves Helm install/upgrade/rollback acceptance, chart-rendered
+Kubernetes API acceptance, preflight validation, and `/healthz/ready` readiness
+(which signals Honua startup and migrations completed) on AKS. It does not
+validate Terraform provisioning, marketplace package publication, sales-offer
+alignment, or any application behavior beyond the readiness contract. Failures
+in those areas are filed and linked in their owning repositories.

--- a/honua/ci-values/aks-smoke-install.yaml
+++ b/honua/ci-values/aks-smoke-install.yaml
@@ -1,0 +1,63 @@
+# AKS customer-operated smoke: install baseline (honua-helm#10).
+#
+# Models the Azure Marketplace customer-operated path: external PostGIS and
+# external Redis (Bitnami subcharts disabled, as in values-prod.yaml), a
+# pre-created runtime Secret, and an immutable release tag for evidence.
+#
+# This file is the chart-side contract input for the AKS install smoke. The
+# operator supplies the live cluster, the runtime Secret, and a concrete image
+# tag or digest via scripts/aks-smoke.sh. Placeholder endpoints below are
+# overridden by the harness (--db-host / --redis-host / --image-* flags); they
+# exist so the file renders and validates offline in CI.
+replicaCount: 1
+
+image:
+  repository: ghcr.io/honua-io/honua-server
+  tag: "latest-aot"
+  pullPolicy: IfNotPresent
+
+# Recreate is the migration-safe default; the AKS install smoke exercises it so
+# old pods stop before new pods start during the inline-migration startup.
+strategy:
+  type: Recreate
+
+resources:
+  requests:
+    cpu: 500m
+    memory: 1Gi
+  limits:
+    cpu: "2"
+    memory: 2Gi
+
+preflight:
+  enabled: true
+  # The registry /v2/ reachability check stays on so the install smoke records
+  # registry reachability from inside the AKS cluster as evidence.
+  registryCheck:
+    enabled: true
+
+ingress:
+  enabled: false
+
+release:
+  id: honua-aks-smoke-install
+  manifest: "aks://honua-helm/10/install"
+
+config:
+  env:
+    ASPNETCORE_ENVIRONMENT: "Production"
+    ASPNETCORE_URLS: "http://+:8080"
+    Deployment__Mode: "SingleInstance"
+    HONUA_SKIP_MIGRATIONS: "false"
+
+# External managed data services (no PostGIS in Bitnami PostgreSQL); the runtime
+# Secret is pre-created by the operator / harness.
+secret:
+  create: false
+  name: honua-aks-runtime
+
+postgresql:
+  enabled: false
+
+redis:
+  enabled: false

--- a/honua/ci-values/aks-smoke-upgrade.yaml
+++ b/honua/ci-values/aks-smoke-upgrade.yaml
@@ -1,0 +1,53 @@
+# AKS customer-operated smoke: upgrade target (honua-helm#10).
+#
+# Applied as the `helm upgrade` step after aks-smoke-install.yaml. It changes
+# release evidence metadata and scales to two replicas to exercise the upgrade
+# path the marketplace listing depends on, while keeping the migration-safe
+# Recreate strategy. Pair with scripts/aks-smoke.sh, which overrides the image
+# tag/digest and data-service endpoints for the live run.
+replicaCount: 2
+
+image:
+  repository: ghcr.io/honua-io/honua-server
+  tag: "latest-aot"
+  pullPolicy: IfNotPresent
+
+strategy:
+  type: Recreate
+
+resources:
+  requests:
+    cpu: 500m
+    memory: 1Gi
+  limits:
+    cpu: "2"
+    memory: 2Gi
+
+preflight:
+  enabled: true
+  registryCheck:
+    enabled: true
+
+ingress:
+  enabled: false
+
+release:
+  id: honua-aks-smoke-upgrade
+  manifest: "aks://honua-helm/10/upgrade"
+
+config:
+  env:
+    ASPNETCORE_ENVIRONMENT: "Production"
+    ASPNETCORE_URLS: "http://+:8080"
+    Deployment__Mode: "SingleInstance"
+    HONUA_SKIP_MIGRATIONS: "false"
+
+secret:
+  create: false
+  name: honua-aks-runtime
+
+postgresql:
+  enabled: false
+
+redis:
+  enabled: false

--- a/scripts/aks-smoke.sh
+++ b/scripts/aks-smoke.sh
@@ -1,0 +1,337 @@
+#!/usr/bin/env bash
+#
+# aks-smoke.sh — AKS install + upgrade + rollback smoke harness for the Honua
+# Helm chart (honua-helm#10).
+#
+# This is the *harness* the operator runs against a live AKS validation cluster
+# that matches the Azure Marketplace customer-operated path. It does not
+# provision a cluster and it does not fabricate evidence: every recorded result
+# comes from the commands it actually runs against the kubeconfig you supply.
+#
+# It captures the evidence the issue's acceptance criteria require:
+#   - chart version and effective app version
+#   - image reference and image digest
+#   - the values file / overlay used (install + upgrade)
+#   - the cluster / runtime target (current kube-context + AKS node summary)
+#   - the exact helm/kubectl commands run (logged with timestamps)
+#   - health-check output (`helm test` readiness logs + probe status)
+#
+# Modes:
+#   (default)   run the live AKS smoke against the current kubeconfig context.
+#   --dry-run   render + lint + kubeconform only, no cluster needed. Use this in
+#               CI or locally to validate the harness and overlays without AKS.
+#
+# Usage:
+#   scripts/aks-smoke.sh \
+#     --release honua \
+#     --namespace honua \
+#     --image-tag v0.3.1-aot \
+#     [--image-digest sha256:<64hex>] \
+#     [--install-values honua/ci-values/aks-smoke-install.yaml] \
+#     [--upgrade-values honua/ci-values/aks-smoke-upgrade.yaml] \
+#     [--set key=value ...] \
+#     [--evidence-dir evidence/aks-<date>] \
+#     [--keep] [--dry-run]
+#
+# The runtime Secret named by the chosen install overlay (default
+# `honua-aks-runtime`) MUST already exist in the target namespace, or be created
+# by passing --create-runtime-secret with the connection inputs below. The
+# harness never writes secret material to the evidence directory.
+#
+set -euo pipefail
+
+# --------------------------------------------------------------------------- #
+# Defaults
+# --------------------------------------------------------------------------- #
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+CHART_DIR="${REPO_ROOT}/honua"
+
+RELEASE="honua"
+NAMESPACE="honua"
+INSTALL_VALUES="${CHART_DIR}/ci-values/aks-smoke-install.yaml"
+UPGRADE_VALUES="${CHART_DIR}/ci-values/aks-smoke-upgrade.yaml"
+IMAGE_REPO="ghcr.io/honua-io/honua-server"
+IMAGE_TAG=""
+IMAGE_DIGEST=""
+RELEASE_ID=""
+RELEASE_MANIFEST=""
+RELEASE_DIGEST=""
+EVIDENCE_DIR=""
+TIMEOUT="10m"
+DRY_RUN="false"
+KEEP="false"
+CREATE_RUNTIME_SECRET="false"
+RUNTIME_SECRET_NAME=""
+declare -a EXTRA_SET=()
+
+# --------------------------------------------------------------------------- #
+# Arg parsing
+# --------------------------------------------------------------------------- #
+die() { echo "ERROR: $*" >&2; exit 2; }
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --release) RELEASE="$2"; shift 2 ;;
+    --namespace) NAMESPACE="$2"; shift 2 ;;
+    --install-values) INSTALL_VALUES="$2"; shift 2 ;;
+    --upgrade-values) UPGRADE_VALUES="$2"; shift 2 ;;
+    --image-repo) IMAGE_REPO="$2"; shift 2 ;;
+    --image-tag) IMAGE_TAG="$2"; shift 2 ;;
+    --image-digest) IMAGE_DIGEST="$2"; shift 2 ;;
+    --release-id) RELEASE_ID="$2"; shift 2 ;;
+    --release-manifest) RELEASE_MANIFEST="$2"; shift 2 ;;
+    --release-digest) RELEASE_DIGEST="$2"; shift 2 ;;
+    --evidence-dir) EVIDENCE_DIR="$2"; shift 2 ;;
+    --timeout) TIMEOUT="$2"; shift 2 ;;
+    --set) EXTRA_SET+=("$2"); shift 2 ;;
+    --create-runtime-secret) CREATE_RUNTIME_SECRET="true"; shift ;;
+    --runtime-secret-name) RUNTIME_SECRET_NAME="$2"; shift 2 ;;
+    --keep) KEEP="true"; shift ;;
+    --dry-run) DRY_RUN="true"; shift ;;
+    -h|--help) sed -n '2,60p' "$0"; exit 0 ;;
+    *) die "unknown argument: $1" ;;
+  esac
+done
+
+[ -d "${CHART_DIR}" ] || die "chart directory not found: ${CHART_DIR}"
+[ -f "${INSTALL_VALUES}" ] || die "install values not found: ${INSTALL_VALUES}"
+[ -f "${UPGRADE_VALUES}" ] || die "upgrade values not found: ${UPGRADE_VALUES}"
+command -v helm >/dev/null 2>&1 || die "helm is required on PATH"
+
+if [ -z "${EVIDENCE_DIR}" ]; then
+  EVIDENCE_DIR="${REPO_ROOT}/evidence/aks-$(date -u +%Y%m%dT%H%M%SZ)"
+fi
+mkdir -p "${EVIDENCE_DIR}"
+LOG="${EVIDENCE_DIR}/commands.log"
+SUMMARY="${EVIDENCE_DIR}/summary.md"
+
+# --------------------------------------------------------------------------- #
+# Command runner: echoes, timestamps, tees output into the evidence log.
+# --------------------------------------------------------------------------- #
+# The command echo and the command's own stderr are appended to the evidence
+# log only; the command's stdout is left intact so callers can redirect a clean
+# `helm template` render into a file. (Use `run_tee` when you also want stdout
+# mirrored to the terminal.)
+run() {
+  local ts
+  ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  echo "+ [${ts}] $*" >> "${LOG}"
+  echo "+ [${ts}] $*" >&2
+  "$@" 2>>"${LOG}"
+}
+
+# Like run, but also mirrors stdout to the terminal and the log. Use for steps
+# whose stdout is human-facing (lint, helm test, history) rather than captured.
+run_tee() {
+  local ts
+  ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  echo "+ [${ts}] $*" | tee -a "${LOG}" >&2
+  "$@" 2>&1 | tee -a "${LOG}"
+  return "${PIPESTATUS[0]}"
+}
+
+# helm --set flags shared by install and upgrade.
+build_set_args() {
+  local -a a=()
+  a+=(--set "image.repository=${IMAGE_REPO}")
+  if [ -n "${IMAGE_DIGEST}" ]; then
+    a+=(--set "image.digest=${IMAGE_DIGEST}")
+    a+=(--set "image.tag=")
+    a+=(--set "image.pullPolicy=IfNotPresent")
+  elif [ -n "${IMAGE_TAG}" ]; then
+    a+=(--set "image.tag=${IMAGE_TAG}")
+  fi
+  [ -n "${RELEASE_ID}" ] && a+=(--set "release.id=${RELEASE_ID}")
+  [ -n "${RELEASE_MANIFEST}" ] && a+=(--set "release.manifest=${RELEASE_MANIFEST}")
+  [ -n "${RELEASE_DIGEST}" ] && a+=(--set "release.digest=${RELEASE_DIGEST}")
+  local kv
+  for kv in "${EXTRA_SET[@]:-}"; do
+    [ -n "${kv}" ] && a+=(--set "${kv}")
+  done
+  printf '%s\n' "${a[@]}"
+}
+
+mapfile -t SET_ARGS < <(build_set_args)
+
+# --------------------------------------------------------------------------- #
+# Evidence header (filled progressively).
+# --------------------------------------------------------------------------- #
+CHART_VERSION="$(helm show chart "${CHART_DIR}" 2>/dev/null | awk -F': ' '/^version:/ {print $2}')"
+APP_VERSION="$(helm show chart "${CHART_DIR}" 2>/dev/null | awk -F': ' '/^appVersion:/ {print $2}')"
+
+{
+  echo "# Honua AKS chart smoke evidence (honua-helm#10)"
+  echo
+  echo "- Generated (UTC): $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  echo "- Mode: $([ "${DRY_RUN}" = "true" ] && echo 'dry-run (no cluster)' || echo 'live AKS')"
+  echo "- Release: \`${RELEASE}\`  Namespace: \`${NAMESPACE}\`"
+  echo "- Chart version: \`${CHART_VERSION}\`  App version: \`${APP_VERSION}\`"
+  echo "- Image repo: \`${IMAGE_REPO}\`"
+  echo "- Image tag: \`${IMAGE_TAG:-<unset>}\`  Image digest: \`${IMAGE_DIGEST:-<unset>}\`"
+  echo "- Install overlay: \`${INSTALL_VALUES#"${REPO_ROOT}"/}\`"
+  echo "- Upgrade overlay: \`${UPGRADE_VALUES#"${REPO_ROOT}"/}\`"
+  echo
+} > "${SUMMARY}"
+
+# --------------------------------------------------------------------------- #
+# DRY RUN: render + lint + kubeconform, no cluster.
+# --------------------------------------------------------------------------- #
+if [ "${DRY_RUN}" = "true" ]; then
+  echo "== DRY RUN: render + lint only, no AKS cluster contacted ==" | tee -a "${LOG}" >&2
+  run_tee helm lint "${CHART_DIR}" -f "${INSTALL_VALUES}" "${SET_ARGS[@]}" \
+    || die "lint failed for install overlay"
+  run_tee helm lint "${CHART_DIR}" -f "${UPGRADE_VALUES}" "${SET_ARGS[@]}" \
+    || die "lint failed for upgrade overlay"
+
+  run helm template "${RELEASE}" "${CHART_DIR}" -n "${NAMESPACE}" \
+    -f "${INSTALL_VALUES}" "${SET_ARGS[@]}" \
+    > "${EVIDENCE_DIR}/render-install.yaml" \
+    || die "install render failed"
+  run helm template "${RELEASE}" "${CHART_DIR}" -n "${NAMESPACE}" --is-upgrade \
+    -f "${UPGRADE_VALUES}" "${SET_ARGS[@]}" \
+    > "${EVIDENCE_DIR}/render-upgrade.yaml" \
+    || die "upgrade render failed"
+
+  if command -v kubeconform >/dev/null 2>&1; then
+    run_tee kubeconform -strict -ignore-missing-schemas -summary \
+      "${EVIDENCE_DIR}/render-install.yaml" || die "kubeconform install failed"
+    run_tee kubeconform -strict -ignore-missing-schemas -summary \
+      "${EVIDENCE_DIR}/render-upgrade.yaml" || die "kubeconform upgrade failed"
+  else
+    echo "kubeconform not on PATH; skipped manifest schema validation" | tee -a "${LOG}" >&2
+  fi
+
+  {
+    echo "## Result"
+    echo
+    echo "Dry-run validation passed: lint + render + kubeconform for the AKS"
+    echo "install and upgrade overlays. NO live AKS install/upgrade was run; this"
+    echo "mode never contacts a cluster and produces no live deployment evidence."
+  } >> "${SUMMARY}"
+  echo
+  echo "Dry-run evidence written to: ${EVIDENCE_DIR}"
+  exit 0
+fi
+
+# --------------------------------------------------------------------------- #
+# LIVE AKS path.
+# --------------------------------------------------------------------------- #
+command -v kubectl >/dev/null 2>&1 || die "kubectl is required for the live smoke"
+
+KCONTEXT="$(kubectl config current-context 2>/dev/null || true)"
+[ -n "${KCONTEXT}" ] || die "no current kube-context; set your AKS kubeconfig first"
+
+cleanup() {
+  if [ "${KEEP}" = "true" ]; then
+    echo "--keep set; leaving release ${RELEASE} in namespace ${NAMESPACE}" | tee -a "${LOG}"
+    return
+  fi
+  echo "== Cleanup: uninstalling ${RELEASE} ==" | tee -a "${LOG}"
+  helm uninstall "${RELEASE}" -n "${NAMESPACE}" --wait --timeout "${TIMEOUT}" \
+    >>"${LOG}" 2>&1 || true
+}
+trap cleanup EXIT
+
+echo "== Cluster target ==" | tee -a "${LOG}"
+{
+  echo
+  echo "## Cluster / runtime target"
+  echo
+  echo "- kube-context: \`${KCONTEXT}\`"
+} >> "${SUMMARY}"
+run kubectl cluster-info | head -5 || true
+run kubectl get nodes -o wide > "${EVIDENCE_DIR}/nodes.txt" || true
+# AKS sanity: surface node labels so reviewers can confirm an Azure target.
+run kubectl get nodes -o jsonpath='{range .items[*]}{.metadata.labels.kubernetes\.io/hostname}{"\t"}{.metadata.labels.kubernetes\.azure\.com/cluster}{"\t"}{.metadata.labels.node\.kubernetes\.io/instance-type}{"\n"}{end}' \
+  > "${EVIDENCE_DIR}/aks-node-labels.txt" 2>/dev/null || true
+
+run kubectl create namespace "${NAMESPACE}" --dry-run=client -o yaml \
+  | kubectl apply -f - || true
+
+# Optionally create the runtime Secret from connection inputs. Secret material
+# is passed via env vars (HONUA_*), never logged, never written to evidence.
+if [ "${CREATE_RUNTIME_SECRET}" = "true" ]; then
+  SECRET_NAME="${RUNTIME_SECRET_NAME:-honua-aks-runtime}"
+  : "${HONUA_DB_CONNECTION:?--create-runtime-secret requires HONUA_DB_CONNECTION env}"
+  : "${HONUA_ADMIN_PASSWORD:?--create-runtime-secret requires HONUA_ADMIN_PASSWORD env}"
+  : "${HONUA_MASTER_KEY:?--create-runtime-secret requires HONUA_MASTER_KEY env}"
+  : "${HONUA_REDIS_CONNECTION:?--create-runtime-secret requires HONUA_REDIS_CONNECTION env}"
+  echo "+ creating runtime Secret ${SECRET_NAME} (values not logged)" | tee -a "${LOG}"
+  kubectl create secret generic "${SECRET_NAME}" -n "${NAMESPACE}" \
+    --from-literal=ConnectionStrings__DefaultConnection="${HONUA_DB_CONNECTION}" \
+    --from-literal=HONUA_ADMIN_PASSWORD="${HONUA_ADMIN_PASSWORD}" \
+    --from-literal=Security__ConnectionEncryption__MasterKey="${HONUA_MASTER_KEY}" \
+    --from-literal=ConnectionStrings__redis="${HONUA_REDIS_CONNECTION}" \
+    --dry-run=client -o yaml | kubectl apply -f - >>"${LOG}" 2>&1
+fi
+
+# ----- INSTALL ----- #
+echo "== Install smoke ==" | tee -a "${LOG}"
+run_tee helm install "${RELEASE}" "${CHART_DIR}" -n "${NAMESPACE}" \
+  -f "${INSTALL_VALUES}" "${SET_ARGS[@]}" \
+  --wait --timeout "${TIMEOUT}" \
+  || die "helm install failed"
+
+run helm test "${RELEASE}" -n "${NAMESPACE}" --logs --timeout "${TIMEOUT}" \
+  | tee "${EVIDENCE_DIR}/healthcheck-install.log" \
+  || die "post-install helm test (readiness health check) failed"
+
+# ----- UPGRADE ----- #
+echo "== Upgrade smoke ==" | tee -a "${LOG}"
+run_tee helm upgrade "${RELEASE}" "${CHART_DIR}" -n "${NAMESPACE}" \
+  -f "${UPGRADE_VALUES}" "${SET_ARGS[@]}" \
+  --wait --timeout "${TIMEOUT}" \
+  || die "helm upgrade failed"
+
+run helm test "${RELEASE}" -n "${NAMESPACE}" --logs --timeout "${TIMEOUT}" \
+  | tee "${EVIDENCE_DIR}/healthcheck-upgrade.log" \
+  || die "post-upgrade helm test (readiness health check) failed"
+
+# ----- ROLLBACK ----- #
+echo "== Rollback smoke ==" | tee -a "${LOG}"
+run_tee helm rollback "${RELEASE}" 1 -n "${NAMESPACE}" --wait --timeout "${TIMEOUT}" \
+  || die "helm rollback failed"
+run helm test "${RELEASE}" -n "${NAMESPACE}" --logs --timeout "${TIMEOUT}" \
+  | tee "${EVIDENCE_DIR}/healthcheck-rollback.log" \
+  || die "post-rollback helm test failed"
+
+# ----- EVIDENCE CAPTURE ----- #
+echo "== Capturing release evidence ==" | tee -a "${LOG}"
+helm history "${RELEASE}" -n "${NAMESPACE}" > "${EVIDENCE_DIR}/helm-history.txt" 2>&1 || true
+helm get notes "${RELEASE}" -n "${NAMESPACE}" > "${EVIDENCE_DIR}/helm-notes.txt" 2>&1 || true
+helm get values "${RELEASE}" -n "${NAMESPACE}" > "${EVIDENCE_DIR}/helm-values.txt" 2>&1 || true
+kubectl get configmap "${RELEASE}-honua-release-info" -n "${NAMESPACE}" -o yaml \
+  > "${EVIDENCE_DIR}/release-info.yaml" 2>&1 || true
+kubectl get deploy,po,svc -n "${NAMESPACE}" -o wide \
+  > "${EVIDENCE_DIR}/workloads.txt" 2>&1 || true
+# Probe status / health surfaces straight from the running pods.
+kubectl get pods -n "${NAMESPACE}" \
+  -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.phase}{"\t"}{.status.conditions[?(@.type=="Ready")].status}{"\n"}{end}' \
+  > "${EVIDENCE_DIR}/pod-readiness.txt" 2>&1 || true
+kubectl get events -n "${NAMESPACE}" --sort-by=.lastTimestamp \
+  > "${EVIDENCE_DIR}/events.txt" 2>&1 || true
+
+# Record the resolved image digest as deployed (authoritative kubelet view).
+kubectl get pods -n "${NAMESPACE}" \
+  -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{range .status.containerStatuses[*]}{.imageID}{" "}{end}{"\n"}{end}' \
+  > "${EVIDENCE_DIR}/image-ids.txt" 2>&1 || true
+
+{
+  echo
+  echo "## Result"
+  echo
+  echo "Live AKS install + upgrade + rollback smoke completed against context"
+  echo "\`${KCONTEXT}\`. Evidence files in this directory:"
+  echo
+  echo '```'
+  ls -1 "${EVIDENCE_DIR}"
+  echo '```'
+  echo
+  echo "Health-check output: \`healthcheck-install.log\`, \`healthcheck-upgrade.log\`,"
+  echo "\`healthcheck-rollback.log\`. Resolved image digests: \`image-ids.txt\`."
+  echo "Release metadata: \`release-info.yaml\`. Command transcript: \`commands.log\`."
+} >> "${SUMMARY}"
+
+echo
+echo "AKS smoke complete. Evidence written to: ${EVIDENCE_DIR}"


### PR DESCRIPTION
Advances honua-helm#10 with the parts that do **not** require a live AKS cluster: the chart-side contract inputs and a parameterized AKS install/upgrade smoke harness. Does **not** close the issue — the live AKS run + evidence capture is still owed.

## What landed

**AKS smoke overlays** (`honua/ci-values/`)
- `aks-smoke-install.yaml` — install baseline for the customer-operated AKS path: external PostGIS + Redis (Bitnami subcharts disabled, as in `values-prod.yaml`), pre-created runtime Secret, migration-safe `Recreate` strategy, preflight hook with registry reachability check on.
- `aks-smoke-upgrade.yaml` — upgrade target applied as the `helm upgrade` step (scales replicas, rotates release evidence metadata).

**Smoke harness** (`scripts/aks-smoke.sh`)
- Runs `install -> helm test -> upgrade -> helm test -> rollback -> helm test` against an operator-supplied kubeconfig.
- Captures the AC-required evidence into a timestamped directory: chart/app version, image reference + kubelet-resolved image digest, values overlays used, cluster/runtime target (kube-context + AKS node labels), full timestamped command transcript, `helm history`, release-info ConfigMap, pod readiness, and `helm test` health-check logs.
- `--dry-run` mode does lint + render + kubeconform only (no cluster), so the harness and overlays can be validated in CI.
- Optional `--create-runtime-secret` reads connection material from `HONUA_*` env vars and never writes secret material to evidence or logs.
- Honest by construction: it does not provision AKS and records only what it actually ran. No fabricated cluster evidence.

**Docs** — `docs/smoke/aks-chart-smoke.md`: operator runbook, acceptance-criteria mapping table, and evidence-directory layout. This is the AKS-specific tracker the marketplace playbook can cite.

**CI** — `lint-chart` now lints + renders both AKS overlays and asserts they carry the operator contract surfaces (preflight hook, release-info, `Recreate`, release-id annotations, no chart-managed PostgreSQL), so the overlays cannot rot.

The operator-ready chart contract from honua-helm#6 (migration/preflight hooks, `/healthz/{live,ready}` probes, rollback-safe digest-pinned values, release-evidence labels/annotations/ConfigMap/NOTES/`helm test`) was already implemented and closed; this PR consumes those surfaces from the AKS path rather than re-implementing them.

## Local validation (real output)

```
helm lint (base, dev, stage, prod, aks-install, aks-upgrade): 6/6 -> 0 chart(s) failed
helm template aks-smoke-install            | kubeconform: 7 resources Valid, 0 Errors
helm template aks-smoke-upgrade --is-upgrade | kubeconform: 7 resources Valid, 0 Errors
scripts/aks-smoke.sh --dry-run (tag mode)    -> lint + render + kubeconform pass
scripts/aks-smoke.sh --dry-run (digest mode) -> digest-pinned image + release annotations render correctly
shellcheck -S warning scripts/aks-smoke.sh   -> clean
bash -n scripts/aks-smoke.sh                 -> syntax OK
```

`helm` v4.2.0; kubeconform v0.6.7; chart deps built from committed `Chart.lock` (postgresql 15.5.38, redis 20.13.4).

## REMAINING: live AKS install+upgrade smoke run + evidence capture (needs AKS creds)

This PR delivers the harness, not the live run. Still owed before honua-helm#10 can close:

- Run `scripts/aks-smoke.sh` (non-dry-run) against a real AKS validation cluster matching the Azure Marketplace customer-operated path. Reuse the `honua-terraform#2` AKS validation cluster when available; otherwise record the temporary AKS setup.
- Capture the resulting evidence directory (chart version, image digests, values overlay, cluster target, commands, health-check output) and attach it to honua-helm#10.
- File and link any failures owned by another repo (e.g. server image, Terraform, marketplace) in that owning repo.

No live AKS credentials were available in this environment, so no cluster evidence is included here and the issue is intentionally left open.
