### PR TITLE
docs: add OpenSSF Scorecard badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Helm Charts
 
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/honua-io/honua-helm/badge)](https://scorecard.dev/viewer/?uri=github.com/honua-io/honua-helm)
+
 - `honua/` - main chart for Honua Server.
 
 Repository layout is intentionally flat after extraction from the monorepo:


### PR DESCRIPTION
Adds the public OpenSSF Scorecard badge to the README (score now published via the org security workflow). Part of the Phase 1 security program (honua-compliance #6).