### PR TITLE
ci: least-privilege workflow token permissions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Summary

Hardens supply-chain posture (OpenSSF Scorecard Token-Permissions) and adds Dependabot coverage.

- **Token-Permissions:** No change required. All three workflows (`ci.yml`, `release.yml`, `security.yml`) already declare a top-level `permissions:` block. `release.yml` keeps its `contents: write` / `packages: write` (helm chart push to `oci://ghcr.io/honua-io/charts`); `security.yml` keeps `security-events: write` / `id-token: write`. Existing SHA-pinned actions are untouched.
- **Dependabot:** Adds `.github/dependabot.yml` (was missing) with weekly `github-actions` updates, minor + patch grouped. No `npm`/`nuget`/`docker` manifests or Dockerfiles exist in this repo (Helm chart only; Dependabot has no native Helm-dependency ecosystem), so `github-actions` is the applicable ecosystem.

## Dependabot alerts (report only)
- No open high/critical alerts. No open Dependabot PRs.

## Scope
Touches only `.github/dependabot.yml`. No workflow YAML changed. Do not merge until reviewed.