### PR TITLE
ci(aks-smoke): exercise the harness in CI + operator AKS workflow (#10)

### DIFF
--- a/.github/workflows/aks-smoke.yml
+++ b/.github/workflows/aks-smoke.yml
@@ -1,0 +1,180 @@
+name: AKS Chart Smoke
+
+# Operator-triggered AKS install + upgrade + rollback smoke for the Honua chart
+# on the Azure Marketplace customer-operated path (honua-helm#10).
+#
+# Two modes, both via workflow_dispatch:
+#   mode=dry-run  (default) — render + lint + kubeconform of the AKS overlays.
+#                 Contacts NO cluster and needs NO secrets. Safe to run anytime;
+#                 also exercised on every push/PR in ci.yml so the harness can't
+#                 rot.
+#   mode=live     — runs scripts/aks-smoke.sh against a real AKS cluster. Gated
+#                 behind the `aks-smoke` GitHub Environment so the OIDC azure
+#                 login + runtime secrets are operator-scoped and reviewable.
+#
+# The live path requires operator-provisioned Azure/AKS and is INTENTIONALLY
+# unable to run without the operator configuring the environment below. Nothing
+# here provisions AKS or fabricates evidence — the harness records only what it
+# actually runs against the kubeconfig it is given.
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "dry-run (no cluster) or live (real AKS)"
+        type: choice
+        options: [dry-run, live]
+        default: dry-run
+      image_tag:
+        description: "Honua image tag for pre-submission validation (e.g. v0.3.1-aot). Prefer image_digest for listing evidence."
+        type: string
+        required: false
+      image_digest:
+        description: "Honua image digest (sha256:...) — pin this for Azure Marketplace listing-submission evidence."
+        type: string
+        required: false
+      release_id:
+        description: "Listing release id recorded in evidence (live mode)."
+        type: string
+        required: false
+      release_manifest:
+        description: "Release manifest URL recorded in evidence (live mode)."
+        type: string
+        required: false
+      release_digest:
+        description: "Release manifest digest (sha256:...) recorded in evidence (live mode)."
+        type: string
+        required: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: aks-smoke-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # DRY-RUN: no cluster, no secrets. Always available.
+  # ---------------------------------------------------------------------------
+  dry-run:
+    if: ${{ inputs.mode == 'dry-run' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+
+      - name: Setup Helm
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4
+
+      - name: Add Bitnami chart repository
+        run: helm repo add bitnami https://charts.bitnami.com/bitnami
+
+      - name: Build chart dependencies
+        run: helm dependency build honua
+
+      - name: Install kubeconform
+        run: |
+          curl -fsSL -o /tmp/kubeconform.tar.gz \
+            https://github.com/yannh/kubeconform/releases/download/v0.6.7/kubeconform-linux-amd64.tar.gz
+          tar -xzf /tmp/kubeconform.tar.gz -C /usr/local/bin kubeconform
+          kubeconform -v
+
+      - name: AKS smoke harness dry-run
+        run: |
+          tag="${{ inputs.image_tag }}"
+          if [ -z "${tag}" ]; then
+            tag="$(helm show chart honua | awk -F': ' '/^appVersion:/ {print $2}')-aot"
+          fi
+          scripts/aks-smoke.sh --dry-run \
+            --image-tag "${tag}" \
+            ${{ inputs.image_digest && format('--image-digest {0}', inputs.image_digest) || '' }} \
+            --evidence-dir evidence/aks-dryrun-${{ github.run_id }}
+
+      - name: Upload dry-run evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: aks-smoke-dryrun-${{ github.run_id }}
+          path: evidence/aks-dryrun-${{ github.run_id }}
+          if-no-files-found: warn
+
+  # ---------------------------------------------------------------------------
+  # LIVE: real AKS cluster. Gated behind the `aks-smoke` Environment so the
+  # operator supplies the OIDC app + AKS + runtime secrets and can require
+  # review. Without that environment configured this job cannot authenticate.
+  # ---------------------------------------------------------------------------
+  live:
+    if: ${{ inputs.mode == 'live' }}
+    runs-on: ubuntu-latest
+    environment: aks-smoke
+    permissions:
+      contents: read
+      id-token: write # OIDC federation for azure/login (no client secret)
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+
+      - name: Setup Helm
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4
+
+      - name: Add Bitnami chart repository
+        run: helm repo add bitnami https://charts.bitnami.com/bitnami
+
+      - name: Build chart dependencies
+        run: helm dependency build honua
+
+      # OPERATOR-SUPPLIED: configure the `aks-smoke` Environment with these
+      # secrets/vars before this can run. AZURE_* identify the OIDC app
+      # (federated to this repo); AKS_* select the validation cluster.
+      - name: Azure login (OIDC, no client secret)
+        uses: azure/login@a65d910e8af852a8061c627c456678983e180302
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Get AKS credentials
+        run: |
+          az aks get-credentials \
+            --resource-group "${{ vars.AKS_RESOURCE_GROUP }}" \
+            --name "${{ vars.AKS_CLUSTER_NAME }}" \
+            --overwrite-existing
+          kubectl config current-context
+
+      - name: Install kubeconform
+        run: |
+          curl -fsSL -o /tmp/kubeconform.tar.gz \
+            https://github.com/yannh/kubeconform/releases/download/v0.6.7/kubeconform-linux-amd64.tar.gz
+          tar -xzf /tmp/kubeconform.tar.gz -C /usr/local/bin kubeconform
+          kubeconform -v
+
+      # Runtime connection material is passed via env (operator-supplied
+      # Environment secrets) and is NEVER written to the evidence directory.
+      - name: Run live AKS smoke (install + upgrade + rollback)
+        env:
+          HONUA_DB_CONNECTION: ${{ secrets.HONUA_DB_CONNECTION }}
+          HONUA_REDIS_CONNECTION: ${{ secrets.HONUA_REDIS_CONNECTION }}
+          HONUA_ADMIN_PASSWORD: ${{ secrets.HONUA_ADMIN_PASSWORD }}
+          HONUA_MASTER_KEY: ${{ secrets.HONUA_MASTER_KEY }}
+        run: |
+          set -euo pipefail
+          digest_args=()
+          [ -n "${{ inputs.image_digest }}" ] && digest_args+=(--image-digest "${{ inputs.image_digest }}")
+          [ -n "${{ inputs.image_tag }}" ] && digest_args+=(--image-tag "${{ inputs.image_tag }}")
+          [ -n "${{ inputs.release_id }}" ] && digest_args+=(--release-id "${{ inputs.release_id }}")
+          [ -n "${{ inputs.release_manifest }}" ] && digest_args+=(--release-manifest "${{ inputs.release_manifest }}")
+          [ -n "${{ inputs.release_digest }}" ] && digest_args+=(--release-digest "${{ inputs.release_digest }}")
+
+          scripts/aks-smoke.sh \
+            --release honua \
+            --namespace honua \
+            --create-runtime-secret \
+            --evidence-dir "evidence/aks-${{ github.run_id }}" \
+            "${digest_args[@]}"
+
+      - name: Upload live AKS smoke evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: aks-smoke-live-${{ github.run_id }}
+          path: evidence/aks-${{ github.run_id }}
+          if-no-files-found: warn

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,6 +292,31 @@ jobs:
             exit 1
           fi
 
+      # Exercise the operator-run AKS smoke harness in its no-cluster mode so the
+      # harness itself (not just the overlays) cannot rot. --dry-run runs
+      # lint + template + kubeconform against the AKS overlays and contacts no
+      # cluster. The live AKS path is operator-run via aks-smoke.yml.
+      - name: Install kubeconform
+        run: |
+          curl -fsSL -o /tmp/kubeconform.tar.gz \
+            https://github.com/yannh/kubeconform/releases/download/v0.6.7/kubeconform-linux-amd64.tar.gz
+          tar -xzf /tmp/kubeconform.tar.gz -C /usr/local/bin kubeconform
+          kubeconform -v
+
+      - name: AKS smoke harness dry-run (no cluster)
+        run: |
+          scripts/aks-smoke.sh --dry-run \
+            --image-tag "$(helm show chart honua | awk -F': ' '/^appVersion:/ {print $2}')-aot" \
+            --evidence-dir /tmp/aks-smoke-dryrun
+
+      - name: Upload AKS smoke dry-run evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: aks-smoke-dryrun
+          path: /tmp/aks-smoke-dryrun
+          if-no-files-found: warn
+
   install-upgrade-rollback-smoke:
     runs-on: ubuntu-latest
     steps:

--- a/docs/smoke/aks-chart-smoke.md
+++ b/docs/smoke/aks-chart-smoke.md
@@ -23,10 +23,37 @@ evidence.
   the evidence the issue's acceptance criteria require. It supports a `--dry-run`
   mode (render + lint + kubeconform, no cluster) that runs in CI so the AKS
   overlays cannot rot.
+- `.github/workflows/aks-smoke.yml` — operator-triggered workflow with two
+  `workflow_dispatch` modes: `dry-run` (no cluster, no secrets) and `live` (real
+  AKS, gated behind the `aks-smoke` GitHub Environment). The live path logs in to
+  Azure via OIDC (`azure/login`, no client secret), pulls AKS credentials, and
+  runs the harness against the cluster.
+- `ci.yml` (job `lint-chart`) invokes `scripts/aks-smoke.sh --dry-run` on every
+  push/PR, so the harness itself — not just the overlays — is exercised
+  continuously and cannot rot.
 
 The harness does **not** provision AKS and does **not** fabricate results. Every
 recorded value comes from a command it actually ran against the kubeconfig you
 supply.
+
+## Running it from GitHub Actions
+
+Dry-run (anyone, no secrets) — Actions → "AKS Chart Smoke" → Run workflow →
+`mode = dry-run`. This renders, lints, and kubeconform-validates the AKS
+overlays and uploads the evidence; it never contacts a cluster.
+
+Live (operator) — first configure the `aks-smoke` GitHub Environment:
+
+- Secrets: `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID` (an
+  OIDC app federated to this repo, see below), plus `HONUA_DB_CONNECTION`,
+  `HONUA_REDIS_CONNECTION`, `HONUA_ADMIN_PASSWORD`, `HONUA_MASTER_KEY`.
+- Variables: `AKS_RESOURCE_GROUP`, `AKS_CLUSTER_NAME`.
+
+The OIDC app needs a federated credential whose subject is
+`repo:honua-io/honua-helm:environment:aks-smoke` and AKS cluster-user access
+(e.g. the "Azure Kubernetes Service Cluster User Role" + a namespace-scoped
+RBAC role). Then dispatch with `mode = live` and an `image_digest` for
+listing-submission evidence.
 
 ## Prerequisites (operator)
 


### PR DESCRIPTION
Advances #10. The AKS smoke harness, overlays, and contract docs already landed in #11; this closes the two remaining authored-asset gaps so the chart is genuinely operator-ready for the Azure Marketplace path.

## Gaps closed
1. **CI never exercised the harness.** `ci.yml` re-rendered the AKS overlays by hand but never invoked `scripts/aks-smoke.sh`, so the harness could rot. The `lint-chart` job now installs kubeconform and runs `scripts/aks-smoke.sh --dry-run` (lint + template + kubeconform, no cluster) on every push/PR, and uploads the dry-run evidence.
2. **No GitHub Actions entry point for the operator AKS run.** New `.github/workflows/aks-smoke.yml` with two `workflow_dispatch` modes:
   - `dry-run` — no cluster, no secrets; anyone can run it.
   - `live` — full install → upgrade → rollback smoke against a real AKS cluster, gated behind the `aks-smoke` GitHub Environment, authenticating via **OIDC `azure/login` (no client secret)** and pulling AKS credentials.
3. **Docs** (`docs/smoke/aks-chart-smoke.md`) now describe both entry points and the exact operator-supplied Environment secrets/variables + OIDC federation subject.

## Validated vs. blocked
- **Statically validated (run here):** `helm lint`, `helm template`, and `kubeconform` pass for both AKS overlays via the harness `--dry-run` (7 resources valid for install and for upgrade). Both workflow YAMLs parse. The `azure/login` action is pinned to the real v2.2.0 commit.
- **Blocked on live Azure (NOT run here):** the live AKS install/upgrade/rollback and its acceptance evidence (image digests, health-check logs, cluster target) require an operator-provisioned AKS cluster and the configured `aks-smoke` Environment. No live cluster was contacted.

## Operator steps to actually smoke against AKS
Configure the `aks-smoke` GitHub Environment, then Actions → "AKS Chart Smoke" → Run workflow → `mode = live`:
- **Secrets:** `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID` (OIDC app federated with subject `repo:honua-io/honua-helm:environment:aks-smoke`); `HONUA_DB_CONNECTION`, `HONUA_REDIS_CONNECTION`, `HONUA_ADMIN_PASSWORD`, `HONUA_MASTER_KEY`.
- **Variables:** `AKS_RESOURCE_GROUP`, `AKS_CLUSTER_NAME`.
- The OIDC app needs AKS cluster-user access; dispatch with an `image_digest` for listing-submission evidence.

Draft — do not merge until the live AKS smoke has run green and evidence is attached.