### PR TITLE
Pin prod image to an immutable identity and add a PodDisruptionBudget

### DIFF
--- a/honua/Chart.yaml
+++ b/honua/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: honua
 description: Honua Server Helm chart
 type: application
-version: 0.2.0
+version: 0.3.0
 appVersion: "0.0.0"
 dependencies:
   - name: postgresql

--- a/honua/README.md
+++ b/honua/README.md
@@ -367,6 +367,9 @@ characters. For non-development deployments, it also fails if
 | `autoscaling.targetCPUUtilizationPercentage` | `70` | CPU utilization threshold for scale decisions. |
 | `autoscaling.targetMemoryUtilizationPercentage` | `80` | Memory utilization threshold for scale decisions. |
 | `autoscaling.behavior` | scale up/down policies | autoscaling/v2 behavior policies and stabilization windows. |
+| `podDisruptionBudget.enabled` | `null` | Render a PodDisruptionBudget. `null` auto-enables it for multi-replica workloads (`autoscaling.enabled` or `replicaCount > 1`); set `true`/`false` to force. |
+| `podDisruptionBudget.minAvailable` | `null` | Minimum available pods during voluntary disruptions. Mutually exclusive with `maxUnavailable`. |
+| `podDisruptionBudget.maxUnavailable` | `null` | Maximum unavailable pods during voluntary disruptions. Defaults to `25%` when both fields are unset. |
 | `ingress.enabled` | false | Enable ingress. |
 | `config.env.*` | N/A | Non-secret environment variables stored in a ConfigMap. |
 | `secret.env.*` | N/A | Secret environment variables stored in a chart-managed Secret. |

--- a/honua/templates/pdb.yaml
+++ b/honua/templates/pdb.yaml
@@ -1,0 +1,29 @@
+{{- $pdb := .Values.podDisruptionBudget | default dict -}}
+{{- $explicitlyEnabled := dig "enabled" nil $pdb -}}
+{{- $multiReplica := or .Values.autoscaling.enabled (gt (int .Values.replicaCount) 1) -}}
+{{- $enabled := ternary $multiReplica (eq $explicitlyEnabled true) (eq $explicitlyEnabled nil) -}}
+{{- if $enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "honua.fullname" . }}
+  labels:
+    {{- include "honua.labels" . | nindent 4 }}
+    {{- include "honua.releaseLabels" . | nindent 4 }}
+spec:
+  {{- $minAvailable := dig "minAvailable" nil $pdb -}}
+  {{- $maxUnavailable := dig "maxUnavailable" nil $pdb -}}
+  {{- if and (ne $minAvailable nil) (ne $maxUnavailable nil) }}
+  {{- fail "Set only one of podDisruptionBudget.minAvailable or podDisruptionBudget.maxUnavailable, not both." }}
+  {{- end }}
+  {{- if ne $minAvailable nil }}
+  minAvailable: {{ $minAvailable }}
+  {{- else if ne $maxUnavailable nil }}
+  maxUnavailable: {{ $maxUnavailable }}
+  {{- else }}
+  maxUnavailable: 25%
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "honua.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/honua/values-prod.yaml
+++ b/honua/values-prod.yaml
@@ -6,9 +6,23 @@
 
 replicaCount: 3
 
+# Production must run a reproducible, immutable image across the whole replica
+# fleet. Do NOT use the moving "latest-aot" tag here: every restart/reschedule
+# could pull a different build, so replicas in the same Deployment can diverge.
+#
+# Pin one of the following before deploying:
+#   * image.digest (strongest): set image.digest to "sha256:<64 hex>" and leave
+#     image.tag empty. pullPolicy must then be IfNotPresent or Never (enforced by
+#     the chart). See honua/ci-values/digest.yaml for the shape.
+#   * an immutable release tag: override image.tag with a concrete "vX.Y.Z-aot"
+#     release tag (the value release CI stamps into values.yaml).
+#
+# By default this overlay inherits values.yaml image.tag, which release CI stamps
+# to the immutable "vX.Y.Z-aot" tag at chart-release time; it intentionally does
+# not re-pin the mutable "latest-aot" tag. pullPolicy is IfNotPresent so a pinned
+# identity is not silently re-pulled.
 image:
-  tag: "latest-aot"
-  pullPolicy: Always
+  pullPolicy: IfNotPresent
 
 resources:
   requests:

--- a/honua/values.schema.json
+++ b/honua/values.schema.json
@@ -262,6 +262,21 @@
         }
       }
     },
+    "podDisruptionBudget": {
+      "type": "object",
+      "description": "PodDisruptionBudget for the Honua Deployment. Rendered automatically for multi-replica workloads unless enabled is set explicitly.",
+      "properties": {
+        "enabled": {
+          "type": ["boolean", "null"]
+        },
+        "minAvailable": {
+          "type": ["integer", "string", "null"]
+        },
+        "maxUnavailable": {
+          "type": ["integer", "string", "null"]
+        }
+      }
+    },
     "nodeSelector": {
       "type": "object"
     },

--- a/honua/values.yaml
+++ b/honua/values.yaml
@@ -156,6 +156,18 @@ autoscaling:
           value: 10
           periodSeconds: 60
 
+# PodDisruptionBudget for the Honua Deployment. It protects multi-replica
+# workloads from full eviction during voluntary disruptions (node drains,
+# cluster upgrades). When enabled is null (the default), a PDB is rendered
+# automatically whenever the workload runs more than one pod (autoscaling.enabled
+# or replicaCount > 1); set enabled to true/false to force it on or off. Set
+# exactly one of minAvailable or maxUnavailable; when both are null the chart
+# defaults to maxUnavailable: 25%.
+podDisruptionBudget:
+  enabled: null
+  minAvailable: null
+  maxUnavailable: null
+
 nodeSelector: {}
 
 tolerations: []


### PR DESCRIPTION
Closes #23
Closes #25

## Summary

Two correctness fixes for the production posture of the Honua chart.

### #23 — Prod overlay no longer ships a mutable image
`honua/values-prod.yaml` previously set `image.tag: "latest-aot"` + `pullPolicy: Always`, which **defeated the immutable `vX.Y.Z-aot` tag that release CI stamps into `values.yaml`** and let a 3–20 replica fleet silently pull divergent builds.

- The overlay now drops its mutable tag override, so it inherits the release-stamped immutable tag, and sets `pullPolicy: IfNotPresent`.
- Added in-file guidance for the strongest option — pinning by `image.digest: sha256:...` (already validated by the chart; `pullPolicy` is now compatible with a digest drop-in).
- No new chart-wide assertion was added: an env-gated "no mutable tag" guard would break the chart's deliberate use of `latest-aot` in `values.yaml` and several `ci-values/*` files. The fix is scoped to the prod overlay where the bug lives.

### #25 — PodDisruptionBudget for multi-replica workloads
Added `honua/templates/pdb.yaml` for the Honua Deployment.

- Auto-enabled for multi-replica workloads (`autoscaling.enabled` or `replicaCount > 1`); single-replica installs (dev, base) render no app PDB.
- Defaults to `maxUnavailable: 25%`; `minAvailable`/`maxUnavailable` are configurable and mutually exclusive.
- New `podDisruptionBudget` values block (`enabled`/`minAvailable`/`maxUnavailable`) is schema-validated and documented; `enabled: null` = auto, `true`/`false` = force.
- Wired to the chart's standard `honua.fullname`/`honua.labels`/`honua.selectorLabels` helpers.

Chart version bumped `0.2.0` → `0.3.0`.

## Not included — #24
`#24` (HPA vs `Deployment__Mode: SingleInstance`) is direction-ambiguous and is **excluded** from this PR. I investigated `honua-server` and posted the findings + a decision request on the issue: MultiNode scale-out is supported but additionally requires a shared cloud `FileStorage` provider that can't be baked into the generic overlay, so the correct fix depends on a maintainer call (go MultiNode vs. pin single-instance).

## Testing
- `helm lint` passes for dev/stage/prod and all exercised `ci-values/*`.
- `helm template` renders cleanly for every overlay.
- Verified: prod renders `imagePullPolicy: IfNotPresent` and inherits the baseline tag; prod/stage render the app PDB (`maxUnavailable: 25%`); dev/base do not render an app PDB (the only dev PDBs are the Bitnami postgresql/redis subcharts); `enabled` force-on/off and `minAvailable` overrides behave as expected; digest pinning still renders.