### PR TITLE
Make HPA and Deployment__Mode consistent in prod/stage overlays

### DIFF
--- a/docs/values-contract.md
+++ b/docs/values-contract.md
@@ -36,6 +36,7 @@ helm upgrade --install honua ./honua \
 | Redis subchart enabled (`redis.enabled=true`) | `redis.auth.enabled=true` | `honua/values.schema.json`, `honua/templates/secret.yaml` |
 | Chart-managed Secret with Redis subchart and no explicit `secret.env.ConnectionStrings__redis` | `redis.auth.password` | `honua/values.schema.json`, `honua/templates/secret.yaml` |
 | Autoscaling (`autoscaling.enabled=true`) | `autoscaling.targetCPUUtilizationPercentage` or `autoscaling.targetMemoryUtilizationPercentage` greater than `0` | `honua/values.schema.json`, `honua/templates/hpa.yaml` |
+| Autoscaling (`autoscaling.enabled=true`) | `config.env.Deployment__Mode` must be `MultiNode` (not `SingleInstance`); MultiNode also requires `ConnectionStrings__redis` and a shared cloud `FileStorage:Provider` of `AwsS3` or `AzureBlob` (`Local` is rejected) | `honua/templates/validations.yaml` (chart-time); MultiNode runtime requirements enforced by Honua Server `ConfigurationValidationService` |
 | RollingUpdate (`strategy.type=RollingUpdate`) | At least one of `strategy.rollingUpdate.maxSurge` or `strategy.rollingUpdate.maxUnavailable` must be non-zero | `honua/values.schema.json` |
 
 The PostgreSQL subchart is development-only. It does not include PostGIS, so
@@ -90,8 +91,8 @@ from rendered ConfigMap and Secret data before template-required checks run.
 | Overlay | Purpose | Runtime secret posture | Notes |
 | --- | --- | --- | --- |
 | `honua/values-dev.yaml` | Local clusters and ephemeral preview namespaces | Chart-managed Secret with development-only strong password and connection-encryption key; PostgreSQL and Redis subcharts enabled | Self-contained for Helm rendering and development smoke. Not for production data because the PostgreSQL subchart is not PostGIS-enabled. |
-| `honua/values-stage.yaml` | Release-candidate validation | Existing Secret named `honua-stage-runtime` | Enables ingress, HPA, observability, and OpenTelemetry with staging-sized resources. Override DNS, TLS, image identity, and secret name per environment. |
-| `honua/values-prod.yaml` | Customer-operated production posture | Existing Secret named `honua-prod-runtime` | Enables ingress, HPA, observability, and OpenTelemetry with production-sized resources. Override DNS, TLS, image identity, provider annotations, and secret name per customer. |
+| `honua/values-stage.yaml` | Release-candidate validation | Existing Secret named `honua-stage-runtime` | Single-instance (`replicaCount: 1`, `Deployment__Mode=SingleInstance`, HPA disabled) so it is internally consistent out of the box. Enables ingress, observability, and OpenTelemetry with staging-sized resources. Override DNS, TLS, image identity, and secret name per environment. For autoscaled HA, opt into MultiNode (see the overlay header). |
+| `honua/values-prod.yaml` | Customer-operated production posture | Existing Secret named `honua-prod-runtime` | Single-instance (`replicaCount: 1`, `Deployment__Mode=SingleInstance`, HPA disabled) so it is internally consistent out of the box. Enables ingress, observability, and OpenTelemetry with production-sized resources. Override DNS, TLS, image identity, provider annotations, and secret name per customer. For autoscaled HA, opt into MultiNode (set `Deployment__Mode=MultiNode`, enable autoscaling, and supply Redis + a shared cloud `FileStorage:Provider`; see the overlay header). |
 
 ## Breaking Changes Policy
 

--- a/honua/Chart.yaml
+++ b/honua/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: honua
 description: Honua Server Helm chart
 type: application
-version: 0.3.0
+version: 0.4.0
 appVersion: "0.0.0"
 dependencies:
   - name: postgresql

--- a/honua/README.md
+++ b/honua/README.md
@@ -73,8 +73,8 @@ Environment overlays are provided for common release lanes:
 | Overlay | Purpose |
 |---------|---------|
 | `values-dev.yaml` | Local and ephemeral development installs with bundled PostgreSQL and Redis dependencies. |
-| `values-stage.yaml` | Staging validation with existing-secret mode, ingress, HPA, observability, and OpenTelemetry. |
-| `values-prod.yaml` | Customer-operated production posture with existing-secret mode, ingress, HPA, observability, and OpenTelemetry. |
+| `values-stage.yaml` | Staging validation with existing-secret mode, ingress, observability, and OpenTelemetry. Single-instance (`replicaCount: 1`, `Deployment__Mode=SingleInstance`, HPA disabled); opt into MultiNode for autoscaled HA. |
+| `values-prod.yaml` | Customer-operated production posture with existing-secret mode, ingress, observability, and OpenTelemetry. Single-instance (`replicaCount: 1`, `Deployment__Mode=SingleInstance`, HPA disabled); opt into MultiNode for autoscaled HA. |
 
 Layer a site-specific file after the environment overlay:
 
@@ -111,6 +111,16 @@ resources:
   limits:
     cpu: "2"
     memory: 2Gi
+
+# The shipped prod/stage overlays run single-instance (Deployment__Mode=SingleInstance,
+# HPA disabled) and are consistent out of the box. To run autoscaled HA, opt into
+# MultiNode here. The chart fails at render time if autoscaling is enabled while
+# Deployment__Mode is SingleInstance, so these settings must change together.
+# MultiNode additionally requires ConnectionStrings__redis (runtime Secret) and a
+# shared cloud FileStorage:Provider of AwsS3 or AzureBlob (Local is rejected).
+config:
+  env:
+    Deployment__Mode: "MultiNode"
 
 autoscaling:
   enabled: true
@@ -363,7 +373,7 @@ characters. For non-development deployments, it also fails if
 | `preflight.registryCheck.enabled` | true | Check the target image registry `/v2/` endpoint before apply. |
 | `terminationGracePeriodSeconds` | 60 | Pod shutdown grace period for lock release and clean termination. |
 | `resources` | requests `250m`/`512Mi`, limits `2`/`2Gi` | CPU/memory requests and limits. Tune for production workloads. |
-| `autoscaling.enabled` | false | Enable HPA. |
+| `autoscaling.enabled` | false | Enable HPA. Requires `config.env.Deployment__Mode=MultiNode` (plus Redis and a shared cloud `FileStorage:Provider`); render fails if enabled while mode is `SingleInstance`. |
 | `autoscaling.targetCPUUtilizationPercentage` | `70` | CPU utilization threshold for scale decisions. |
 | `autoscaling.targetMemoryUtilizationPercentage` | `80` | Memory utilization threshold for scale decisions. |
 | `autoscaling.behavior` | scale up/down policies | autoscaling/v2 behavior policies and stabilization windows. |

--- a/honua/ci-values/autoscaling-cpu.yaml
+++ b/honua/ci-values/autoscaling-cpu.yaml
@@ -4,6 +4,11 @@ secret:
     HONUA_ADMIN_PASSWORD: "CiAdminPassword1!"
     Security__ConnectionEncryption__MasterKey: "ci-connection-encryption-master-key-00000001"
     ConnectionStrings__redis: "redis:6379,password=ci-redis-password"
+# Autoscaling (horizontal scale-out) is only coherent under MultiNode mode, which
+# also requires Redis (above) and a shared cloud FileStorage provider at runtime.
+config:
+  env:
+    Deployment__Mode: "MultiNode"
 autoscaling:
   enabled: true
   targetCPUUtilizationPercentage: 70

--- a/honua/ci-values/autoscaling-invalid.yaml
+++ b/honua/ci-values/autoscaling-invalid.yaml
@@ -4,6 +4,12 @@ secret:
     HONUA_ADMIN_PASSWORD: "CiAdminPassword1!"
     Security__ConnectionEncryption__MasterKey: "ci-connection-encryption-master-key-00000001"
     ConnectionStrings__redis: "redis:6379,password=ci-redis-password"
+# MultiNode keeps the only intentional defect this fixture exercises the
+# autoscaling target-utilization guard (both targets are 0), not the
+# SingleInstance/autoscaling contradiction.
+config:
+  env:
+    Deployment__Mode: "MultiNode"
 autoscaling:
   enabled: true
   targetCPUUtilizationPercentage: 0

--- a/honua/templates/NOTES.txt
+++ b/honua/templates/NOTES.txt
@@ -38,6 +38,20 @@ WARNING: Recreate with more than one desired replica scales all old pods down
 before new pods start. This is migration-safe but causes upgrade downtime.
 {{- end }}
 
+{{- $deploymentMode := trim (default "SingleInstance" (dig "env" "Deployment__Mode" "SingleInstance" .Values.config)) }}
+{{- if and (not .Values.autoscaling.enabled) (eq $deploymentMode "SingleInstance") }}
+
+This release runs in SingleInstance mode with one server replica. To scale out to
+horizontally autoscaled HA, supply an override that:
+  1. sets config.env.Deployment__Mode: "MultiNode";
+  2. enables autoscaling (autoscaling.enabled=true) or raises replicaCount;
+  3. provides ConnectionStrings__redis; and
+  4. sets a shared cloud FileStorage:Provider (AwsS3 or AzureBlob; Local is
+     rejected in MultiNode), with its bucket/region or connection-string/container.
+The chart fails at render time if autoscaling is enabled while
+Deployment__Mode is SingleInstance, so change these settings together.
+{{- end }}
+
 See docs/contract.md in this chart repository for the durable operator-facing
 contract, including probe tuning, image identity, preflight scope, and rollback
 semantics.

--- a/honua/templates/validations.yaml
+++ b/honua/templates/validations.yaml
@@ -34,3 +34,8 @@
 {{- if and $appVersion (not (regexMatch $labelValuePattern $appVersion)) -}}
 {{- fail "release.appVersion, or Chart.AppVersion when release.appVersion is empty, must be a valid Kubernetes label value: 63 characters or less, using letters, numbers, '_', '.', or '-', and starting and ending with a letter or number." -}}
 {{- end -}}
+
+{{- $deploymentMode := trim (default "SingleInstance" (dig "env" "Deployment__Mode" "SingleInstance" .Values.config)) -}}
+{{- if and .Values.autoscaling.enabled (eq $deploymentMode "SingleInstance") -}}
+{{- fail "autoscaling.enabled is incompatible with config.env.Deployment__Mode=SingleInstance: a single-instance server does not coordinate multiple replicas. Either set autoscaling.enabled=false and pin replicaCount: 1, or switch to horizontally scaled HA by setting config.env.Deployment__Mode=MultiNode and supplying ConnectionStrings__redis plus a shared cloud FileStorage:Provider (AwsS3 or AzureBlob; Local is rejected in MultiNode)." -}}
+{{- end -}}

--- a/honua/values-prod.yaml
+++ b/honua/values-prod.yaml
@@ -3,8 +3,23 @@
 # name, and provider-specific ingress annotations. The runtime secret must
 # contain ConnectionStrings__DefaultConnection, HONUA_ADMIN_PASSWORD,
 # Security__ConnectionEncryption__MasterKey, and ConnectionStrings__redis.
+#
+# This overlay ships a single-instance deployment (replicaCount: 1,
+# Deployment__Mode=SingleInstance) so it is internally consistent and works out
+# of the box. The Honua Server does not coordinate multiple replicas in
+# SingleInstance mode, so the HorizontalPodAutoscaler is disabled here.
+#
+# To opt into horizontally scaled HA, supply a site-specific override that:
+#   1. sets config.env.Deployment__Mode: "MultiNode";
+#   2. enables autoscaling (autoscaling.enabled: true) or raises replicaCount;
+#   3. provides ConnectionStrings__redis (shared cache / coordination); and
+#   4. configures a shared cloud FileStorage provider — FileStorage:Provider must
+#      be AwsS3 or AzureBlob (Local storage is rejected in MultiNode), with the
+#      provider's bucket/region or connection-string/container settings.
+# The chart fails at render time if autoscaling is enabled while
+# Deployment__Mode is SingleInstance, so these settings must change together.
 
-replicaCount: 3
+replicaCount: 1
 
 # Production must run a reproducible, immutable image across the whole replica
 # fleet. Do NOT use the moving "latest-aot" tag here: every restart/reschedule
@@ -32,8 +47,11 @@ resources:
     cpu: "4"
     memory: 8Gi
 
+# Disabled because this overlay runs in SingleInstance mode. Enable only as part
+# of a MultiNode HA override (see the header comment) that also supplies Redis
+# and a shared cloud FileStorage provider.
 autoscaling:
-  enabled: true
+  enabled: false
   minReplicas: 3
   maxReplicas: 20
   targetCPUUtilizationPercentage: 70

--- a/honua/values-stage.yaml
+++ b/honua/values-stage.yaml
@@ -2,8 +2,23 @@
 # Pair this file with a site-specific override for ingress class, DNS, TLS, image
 # tag, and the pre-created runtime secret name when defaults do not match. The
 # runtime secret must include ConnectionStrings__redis for durable event storage.
+#
+# This overlay ships a single-instance deployment (replicaCount: 1,
+# Deployment__Mode=SingleInstance) so it is internally consistent and works out
+# of the box. The Honua Server does not coordinate multiple replicas in
+# SingleInstance mode, so the HorizontalPodAutoscaler is disabled here.
+#
+# To opt into horizontally scaled HA, supply a site-specific override that:
+#   1. sets config.env.Deployment__Mode: "MultiNode";
+#   2. enables autoscaling (autoscaling.enabled: true) or raises replicaCount;
+#   3. provides ConnectionStrings__redis (shared cache / coordination); and
+#   4. configures a shared cloud FileStorage provider — FileStorage:Provider must
+#      be AwsS3 or AzureBlob (Local storage is rejected in MultiNode), with the
+#      provider's bucket/region or connection-string/container settings.
+# The chart fails at render time if autoscaling is enabled while
+# Deployment__Mode is SingleInstance, so these settings must change together.
 
-replicaCount: 2
+replicaCount: 1
 
 image:
   tag: "latest-aot"
@@ -17,8 +32,11 @@ resources:
     cpu: "2"
     memory: 2Gi
 
+# Disabled because this overlay runs in SingleInstance mode. Enable only as part
+# of a MultiNode HA override (see the header comment) that also supplies Redis
+# and a shared cloud FileStorage provider.
 autoscaling:
-  enabled: true
+  enabled: false
   minReplicas: 2
   maxReplicas: 6
   targetCPUUtilizationPercentage: 70

--- a/honua/values.yaml
+++ b/honua/values.yaml
@@ -136,6 +136,13 @@ preflight:
 
 # HorizontalPodAutoscaler. When enabled, at least one target utilization value
 # must be greater than 0; the chart validates this at render time.
+#
+# Horizontal scale-out is only coherent in MultiNode mode. The chart fails at
+# render time if autoscaling.enabled is true while
+# config.env.Deployment__Mode is "SingleInstance" (the default). To run
+# autoscaled HA, set Deployment__Mode: "MultiNode" and also supply
+# ConnectionStrings__redis plus a shared cloud FileStorage:Provider (AwsS3 or
+# AzureBlob; Local is rejected in MultiNode).
 autoscaling:
   enabled: false
   minReplicas: 2
@@ -185,6 +192,10 @@ config:
     HONUA_OBSERVABILITY: "false"
     HONUA_OPENTELEMETRY: "false"
     HONUA_SKIP_MIGRATIONS: "false"
+    # SingleInstance runs one coordinated server. Set MultiNode for horizontally
+    # scaled HA; MultiNode additionally requires ConnectionStrings__redis and a
+    # shared cloud FileStorage:Provider (AwsS3 or AzureBlob). Enabling autoscaling
+    # while this is SingleInstance fails render (see autoscaling above).
     Deployment__Mode: "SingleInstance"
     Public__BaseUrl: ""
     ASPNETCORE_ENVIRONMENT: "Production"


### PR DESCRIPTION
Closes #24.

The prod/stage overlays enabled a HorizontalPodAutoscaler (scaling 3-20 / 2-6 replicas) while `config.env.Deployment__Mode` was `SingleInstance` — a contradiction. Per the prior investigation, Honua Server only coordinates multiple replicas under `Deployment__Mode=MultiNode`, which additionally requires `ConnectionStrings__redis` and a shared cloud `FileStorage:Provider` (`AwsS3`/`AzureBlob`; `Local` is rejected). Those site-specific storage settings can't be baked into a generic shipped overlay, so the safe shipped default is single-instance.

## Approach

**1. Chart-time guard** (`templates/validations.yaml`): fails render with an actionable message when `autoscaling.enabled && Deployment__Mode == "SingleInstance"`, telling the operator to either disable autoscaling or switch to MultiNode (with Redis + cloud FileStorage).

**2. Self-consistent overlays**: prod/stage now disable the HPA and pin `replicaCount: 1` with `Deployment__Mode=SingleInstance` (consistent + works out of the box). Overlay headers, `NOTES.txt`, `values.yaml` comments, and docs explain how to opt into MultiNode HA (set `Deployment__Mode=MultiNode`, enable autoscaling, supply Redis + cloud FileStorage).

**3. Consistent ci-values**: `autoscaling-cpu` sets `Deployment__Mode=MultiNode` so it renders cleanly; `autoscaling-invalid` also sets MultiNode so the only defect it exercises remains the autoscaling target-utilization guard (the "must fail" CI fixture still fails for its intended reason).

Chart version bumped `0.2.0` -> `0.3.0`.

## Verification

- `helm lint` passes for dev/stage/prod and all valid `ci-values/*`.
- `helm template` renders cleanly for dev/stage/prod (incl. `--is-upgrade`) and every valid `ci-values/*`; prod/stage now emit zero `HorizontalPodAutoscaler` objects and `replicas: 1`.
- The new guard fires on a deliberate contradiction (`--set autoscaling.enabled=true --set config.env.Deployment__Mode=SingleInstance`) with a clear message.
- MultiNode + autoscaling renders successfully.
- `ci-values/autoscaling-invalid.yaml` still fails render (the CI "guard fails invalid config" step).