### PR TITLE
feat(chart): observability receiver wiring + Prometheus integration (no more blind deployments)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,22 @@ jobs:
       - name: Render templates (redis auth)
         run: helm template honua ./honua -f honua/ci-values/redis-auth.yaml > /tmp/honua-rendered-redis-auth.yaml
 
+      - name: Render templates (observability)
+        run: helm template honua ./honua -f honua/ci-values/observability.yaml > /tmp/honua-rendered-observability.yaml
+
+      - name: Assert observability resources render
+        run: |
+          set -euo pipefail
+          grep -q 'kind: ServiceMonitor' /tmp/honua-rendered-observability.yaml
+          grep -q 'kind: PrometheusRule' /tmp/honua-rendered-observability.yaml
+          grep -q 'OTEL_EXPORTER_OTLP_ENDPOINT' /tmp/honua-rendered-observability.yaml
+          grep -q 'prometheus.io/scrape: "true"' /tmp/honua-rendered-observability.yaml
+          # Metrics resources must NOT render in the baseline (opt-in only).
+          if grep -q 'kind: ServiceMonitor' /tmp/honua-rendered-base.yaml; then
+            echo "ServiceMonitor must not render without metrics.serviceMonitor.enabled."
+            exit 1
+          fi
+
       - name: Render templates (digest image)
         run: helm template honua ./honua -f honua/ci-values/digest.yaml > /tmp/honua-rendered-digest.yaml
 
@@ -291,6 +307,22 @@ jobs:
             cat /tmp/honua-rendered-redis-missing.yaml
             exit 1
           fi
+
+      - name: Validate observability-without-receiver guard fails invalid config
+        run: |
+          set +e
+          helm template honua ./honua \
+            -f honua/ci-values/base.yaml \
+            --set config.env.HONUA_OPENTELEMETRY=true \
+            > /tmp/honua-rendered-observability-no-receiver.yaml 2>&1
+          status=$?
+          set -e
+          if [[ "${status}" -eq 0 ]]; then
+            echo "Expected observability enabled without a receiver to fail."
+            cat /tmp/honua-rendered-observability-no-receiver.yaml
+            exit 1
+          fi
+          grep -q "no telemetry receiver is configured" /tmp/honua-rendered-observability-no-receiver.yaml
 
       # Exercise the operator-run AKS smoke harness in its no-cluster mode so the
       # harness itself (not just the overlays) cannot rot. --dry-run runs

--- a/honua/README.md
+++ b/honua/README.md
@@ -401,6 +401,69 @@ The chart configures probes on:
 
 The full operator contract is documented in [`docs/contract.md`](../docs/contract.md).
 
+## Observability and metrics
+
+Honua Server emits OpenTelemetry traces and metrics when
+`config.env.HONUA_OPENTELEMETRY` (or `HONUA_OBSERVABILITY`) is `"true"` (the
+default in the stage and prod overlays). That telemetry needs a **receiver**, so
+the chart fails render when observability is enabled without one. Configure at
+least one of the following.
+
+### OpenTelemetry collector (OTLP, push)
+
+```yaml
+config:
+  env:
+    HONUA_OPENTELEMETRY: "true"
+observability:
+  otlpEndpoint: "http://otel-collector.observability.svc:4317"
+  otlpProtocol: "grpc"   # or "http/protobuf" (port 4318)
+```
+
+When `observability.otlpEndpoint` is set the chart injects the standard
+`OTEL_EXPORTER_OTLP_ENDPOINT` / `OTEL_EXPORTER_OTLP_PROTOCOL` environment
+variables so the server's OpenTelemetry SDK exports to the collector.
+
+### Prometheus (scrape)
+
+For a Prometheus Operator cluster, enable a `ServiceMonitor` and the baseline
+`PrometheusRule` availability alerts:
+
+```yaml
+metrics:
+  serviceMonitor:
+    enabled: true
+    path: /metrics
+    interval: 30s
+    labels:
+      release: kube-prometheus-stack   # match your Prometheus ruleSelector/serviceMonitorSelector
+  prometheusRule:
+    enabled: true
+    labels:
+      release: kube-prometheus-stack
+```
+
+For a non-Operator Prometheus that discovers targets via annotations, use
+`metrics.serviceAnnotations.enabled: true` instead, which stamps
+`prometheus.io/scrape`, `prometheus.io/port`, and `prometheus.io/path` on the
+Service.
+
+The `ServiceMonitor`/`PrometheusRule` resources require the Prometheus Operator
+CRDs and a server build that exposes a Prometheus endpoint at the configured
+port/path. The shipped `PrometheusRule` alerts on availability
+(`kube_deployment_status_replicas_available == 0`) and crash-looping via
+kube-state-metrics, so it does not depend on any application metric being
+emitted. Application-level alerts (for example a GeoServices in-band error-rate
+alert) are added once the server exposes the corresponding metric.
+
+| Value | Default | Description |
+|-------|---------|-------------|
+| `observability.otlpEndpoint` | `""` | OTLP collector endpoint; injected as `OTEL_EXPORTER_OTLP_ENDPOINT`. Required (with the scrape options) when observability is enabled. |
+| `observability.otlpProtocol` | `grpc` | OTLP protocol (`grpc` or `http/protobuf`). |
+| `metrics.serviceMonitor.enabled` | false | Render a Prometheus Operator `ServiceMonitor`. |
+| `metrics.serviceAnnotations.enabled` | false | Stamp `prometheus.io/*` scrape annotations on the Service. |
+| `metrics.prometheusRule.enabled` | false | Render the baseline availability `PrometheusRule`. |
+
 ## Geospatial HPA tuning guidance
 
 The default HPA thresholds are tuned for mixed geospatial workloads:

--- a/honua/ci-values/observability.yaml
+++ b/honua/ci-values/observability.yaml
@@ -1,0 +1,30 @@
+# Exercises the observability/metrics integration: OTLP endpoint wiring plus the
+# ServiceMonitor, Prometheus scrape annotations, and PrometheusRule resources.
+config:
+  env:
+    HONUA_OBSERVABILITY: "true"
+    HONUA_OPENTELEMETRY: "true"
+
+observability:
+  otlpEndpoint: "http://otel-collector.observability.svc:4317"
+  otlpProtocol: "grpc"
+
+metrics:
+  serviceMonitor:
+    enabled: true
+    interval: 15s
+    labels:
+      release: kube-prometheus-stack
+  serviceAnnotations:
+    enabled: true
+  prometheusRule:
+    enabled: true
+    labels:
+      release: kube-prometheus-stack
+
+secret:
+  env:
+    ConnectionStrings__DefaultConnection: "Host=postgres;Port=5432;Database=honua;Username=honua;Password=ci-password"
+    HONUA_ADMIN_PASSWORD: "CiAdminPassword1!"
+    Security__ConnectionEncryption__MasterKey: "ci-connection-encryption-master-key-00000001"
+    ConnectionStrings__redis: "redis:6379,password=ci-redis-password"

--- a/honua/templates/deployment.yaml
+++ b/honua/templates/deployment.yaml
@@ -67,9 +67,18 @@ spec:
             {{- with .Values.extraEnvFrom }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
-          {{- with .Values.extraEnv }}
+          {{- $otlpEndpoint := trim (default "" (dig "otlpEndpoint" "" (.Values.observability | default dict))) }}
+          {{- if or $otlpEndpoint .Values.extraEnv }}
           env:
+            {{- if $otlpEndpoint }}
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: {{ $otlpEndpoint | quote }}
+            - name: OTEL_EXPORTER_OTLP_PROTOCOL
+              value: {{ default "grpc" (dig "otlpProtocol" "grpc" (.Values.observability | default dict)) | quote }}
+            {{- end }}
+            {{- with .Values.extraEnv }}
             {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- end }}
           livenessProbe:
             {{- toYaml .Values.livenessProbe | nindent 12 }}

--- a/honua/templates/prometheusrule.yaml
+++ b/honua/templates/prometheusrule.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.metrics.prometheusRule.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ include "honua.fullname" . }}
+  labels:
+    {{- include "honua.labels" . | nindent 4 }}
+    {{- with .Values.metrics.prometheusRule.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  groups:
+    - name: honua.availability
+      rules:
+        - alert: HonuaNoAvailableReplicas
+          expr: 'kube_deployment_status_replicas_available{namespace="{{ .Release.Namespace }}",deployment="{{ include "honua.fullname" . }}"} == 0'
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Honua has no available replicas"
+            description: 'Deployment {{ include "honua.fullname" . }} in namespace {{ .Release.Namespace }} has had zero available replicas for 5 minutes.'
+        - alert: HonuaPodCrashLooping
+          expr: 'increase(kube_pod_container_status_restarts_total{namespace="{{ .Release.Namespace }}",container="honua"}[15m]) > 3'
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Honua container is restarting frequently"
+            description: 'A Honua container in namespace {{ .Release.Namespace }} has restarted more than 3 times in 15 minutes.'
+{{- end }}

--- a/honua/templates/service.yaml
+++ b/honua/templates/service.yaml
@@ -4,9 +4,16 @@ metadata:
   name: {{ include "honua.fullname" . }}
   labels:
     {{- include "honua.labels" . | nindent 4 }}
-  {{- with .Values.service.annotations }}
+  {{- if or .Values.service.annotations .Values.metrics.serviceAnnotations.enabled }}
   annotations:
+    {{- with .Values.service.annotations }}
     {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- if .Values.metrics.serviceAnnotations.enabled }}
+    prometheus.io/scrape: "true"
+    prometheus.io/port: {{ .Values.service.targetPort | quote }}
+    prometheus.io/path: {{ .Values.metrics.serviceAnnotations.path | quote }}
+    {{- end }}
   {{- end }}
 spec:
   type: {{ .Values.service.type }}

--- a/honua/templates/servicemonitor.yaml
+++ b/honua/templates/servicemonitor.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "honua.fullname" . }}
+  labels:
+    {{- include "honua.labels" . | nindent 4 }}
+    {{- with .Values.metrics.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "honua.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: {{ .Values.metrics.serviceMonitor.port | quote }}
+      path: {{ .Values.metrics.serviceMonitor.path | quote }}
+      interval: {{ .Values.metrics.serviceMonitor.interval | quote }}
+      scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout | quote }}
+{{- end }}

--- a/honua/templates/validations.yaml
+++ b/honua/templates/validations.yaml
@@ -39,3 +39,23 @@
 {{- if and .Values.autoscaling.enabled (eq $deploymentMode "SingleInstance") -}}
 {{- fail "autoscaling.enabled is incompatible with config.env.Deployment__Mode=SingleInstance: a single-instance server does not coordinate multiple replicas. Either set autoscaling.enabled=false and pin replicaCount: 1, or switch to horizontally scaled HA by setting config.env.Deployment__Mode=MultiNode and supplying ConnectionStrings__redis plus a shared cloud FileStorage:Provider (AwsS3 or AzureBlob; Local is rejected in MultiNode)." -}}
 {{- end -}}
+
+{{- /* When the server is told to emit telemetry, require a receiver so the
+       chart cannot ship "observability on, nothing listening". A receiver is an
+       OTLP collector endpoint, a Prometheus ServiceMonitor, or Prometheus scrape
+       annotations. */ -}}
+{{- $configEnv := get (.Values.config | default dict) "env" | default dict -}}
+{{- $otel := lower (trim (toString (default "" (get $configEnv "HONUA_OPENTELEMETRY")))) -}}
+{{- $obs := lower (trim (toString (default "" (get $configEnv "HONUA_OBSERVABILITY")))) -}}
+{{- if or (eq $otel "true") (eq $obs "true") -}}
+{{- $observability := .Values.observability | default dict -}}
+{{- $metrics := .Values.metrics | default dict -}}
+{{- $serviceMonitor := get $metrics "serviceMonitor" | default dict -}}
+{{- $serviceAnnotations := get $metrics "serviceAnnotations" | default dict -}}
+{{- $hasOtlp := ne (trim (toString (default "" (get $observability "otlpEndpoint")))) "" -}}
+{{- $hasServiceMonitor := eq (toString (default false (get $serviceMonitor "enabled"))) "true" -}}
+{{- $hasScrapeAnnotations := eq (toString (default false (get $serviceAnnotations "enabled"))) "true" -}}
+{{- if not (or $hasOtlp $hasServiceMonitor $hasScrapeAnnotations) -}}
+{{- fail "config.env.HONUA_OPENTELEMETRY/HONUA_OBSERVABILITY is enabled but no telemetry receiver is configured. Set observability.otlpEndpoint to an OpenTelemetry collector, or enable metrics.serviceMonitor.enabled / metrics.serviceAnnotations.enabled. Otherwise disable observability so the deployment is not blind." -}}
+{{- end -}}
+{{- end -}}

--- a/honua/values-prod.yaml
+++ b/honua/values-prod.yaml
@@ -83,6 +83,13 @@ config:
     ASPNETCORE_ENVIRONMENT: "Production"
     ASPNETCORE_URLS: "http://+:8080"
 
+# Observability is enabled above, so a receiver is required. Point this at your
+# OpenTelemetry collector (override the host/port for your cluster). Alternatively
+# enable metrics.serviceMonitor / metrics.serviceAnnotations to scrape Prometheus.
+observability:
+  otlpEndpoint: "http://otel-collector.observability.svc:4317"
+  otlpProtocol: "grpc"
+
 secret:
   create: false
   name: honua-prod-runtime

--- a/honua/values-stage.yaml
+++ b/honua/values-stage.yaml
@@ -68,6 +68,13 @@ config:
     ASPNETCORE_ENVIRONMENT: "Staging"
     ASPNETCORE_URLS: "http://+:8080"
 
+# Observability is enabled above, so a receiver is required. Point this at your
+# OpenTelemetry collector (override the host/port for your cluster). Alternatively
+# enable metrics.serviceMonitor / metrics.serviceAnnotations to scrape Prometheus.
+observability:
+  otlpEndpoint: "http://otel-collector.observability.svc:4317"
+  otlpProtocol: "grpc"
+
 secret:
   create: false
   name: honua-stage-runtime

--- a/honua/values.schema.json
+++ b/honua/values.schema.json
@@ -286,6 +286,49 @@
     "affinity": {
       "type": "object"
     },
+    "observability": {
+      "type": "object",
+      "description": "OpenTelemetry receiver wiring for the server's emitted telemetry.",
+      "properties": {
+        "otlpEndpoint": {
+          "type": "string"
+        },
+        "otlpProtocol": {
+          "type": "string"
+        }
+      }
+    },
+    "metrics": {
+      "type": "object",
+      "description": "Prometheus metrics integration (ServiceMonitor, scrape annotations, PrometheusRule).",
+      "properties": {
+        "serviceMonitor": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "port": { "type": ["string", "integer"] },
+            "path": { "type": "string" },
+            "interval": { "type": "string" },
+            "scrapeTimeout": { "type": "string" },
+            "labels": { "type": "object" }
+          }
+        },
+        "serviceAnnotations": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "path": { "type": "string" }
+          }
+        },
+        "prometheusRule": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "labels": { "type": "object" }
+          }
+        }
+      }
+    },
     "config": {
       "type": "object",
       "description": "Chart-managed or externally managed ConfigMap settings.",

--- a/honua/values.yaml
+++ b/honua/values.yaml
@@ -227,6 +227,49 @@ extraEnvFrom: []
 extraVolumes: []
 extraVolumeMounts: []
 
+# Observability. Honua Server emits OpenTelemetry traces/metrics when
+# config.env.HONUA_OPENTELEMETRY (or HONUA_OBSERVABILITY) is "true". Those signals
+# need a receiver: set observability.otlpEndpoint to an OpenTelemetry collector,
+# or enable a metrics.serviceMonitor / metrics.serviceAnnotations scrape target.
+# The chart fails render if observability is enabled with no receiver configured
+# (see templates/validations.yaml), so prod/stage cannot ship "blind".
+observability:
+  # OTLP exporter endpoint (OpenTelemetry collector). When set, the chart injects
+  # the standard OTEL_EXPORTER_OTLP_ENDPOINT/OTEL_EXPORTER_OTLP_PROTOCOL env vars
+  # so the server's OpenTelemetry SDK exports to the collector.
+  # Example: http://otel-collector.observability.svc:4317
+  otlpEndpoint: ""
+  # OTLP protocol: "grpc" (default, port 4317) or "http/protobuf" (port 4318).
+  otlpProtocol: "grpc"
+
+# Prometheus metrics integration. These resources require the Prometheus Operator
+# CRDs (ServiceMonitor/PrometheusRule) and/or a Prometheus that honors scrape
+# annotations, plus a server build that exposes a Prometheus endpoint at the
+# configured port/path. All are opt-in (disabled by default) so the chart renders
+# on clusters without the Prometheus Operator.
+metrics:
+  # Prometheus Operator ServiceMonitor scraping the server metrics endpoint.
+  serviceMonitor:
+    enabled: false
+    # Service port name to scrape (the chart Service names its port "http").
+    port: http
+    path: /metrics
+    interval: 30s
+    scrapeTimeout: 10s
+    # Extra labels so a Prometheus Operator release selector can adopt this.
+    labels: {}
+  # Prometheus scrape annotations on the Service (for non-Operator Prometheus
+  # that discovers targets via prometheus.io/* annotations).
+  serviceAnnotations:
+    enabled: false
+    path: /metrics
+  # PrometheusRule with baseline availability alerts (zero available replicas,
+  # crash-looping). These alert on kube-state-metrics series, so they do not
+  # depend on any application metric being emitted yet.
+  prometheusRule:
+    enabled: false
+    labels: {}
+
 # Optional Bitnami PostgreSQL dependency. This is development-only because the
 # subchart does not include PostGIS; production should use an external
 # PostGIS-enabled database and provide ConnectionStrings__DefaultConnection.


### PR DESCRIPTION
## Summary

Fixes the S1 monitoring gap: the chart shipped **no** monitoring resources, and stage/prod enabled observability with **no receiver**, so emitted telemetry had nowhere to go.

Fixes #31.

## Changes

### OTLP receiver wiring
- New `observability.otlpEndpoint` / `observability.otlpProtocol` values. When set, the deployment injects the standard `OTEL_EXPORTER_OTLP_ENDPOINT` / `OTEL_EXPORTER_OTLP_PROTOCOL` env vars so the server's OpenTelemetry SDK exports to a collector.
- Stage and prod overlays now set an example collector endpoint (override per cluster).

### Receiver gate
- `validations.yaml` fails render when `HONUA_OPENTELEMETRY`/`HONUA_OBSERVABILITY` is enabled but no receiver is configured (OTLP endpoint, ServiceMonitor, or scrape annotations). Observability-enabled-but-blind is now rejected before install.

### Prometheus integration (opt-in)
- `templates/servicemonitor.yaml` — Prometheus Operator `ServiceMonitor`, gated by `metrics.serviceMonitor.enabled`.
- `templates/prometheusrule.yaml` — baseline availability alerts (`HonuaNoAvailableReplicas`, `HonuaPodCrashLooping`) keyed on kube-state-metrics, gated by `metrics.prometheusRule.enabled`.
- Service `prometheus.io/*` scrape annotations, gated by `metrics.serviceAnnotations.enabled`.
- All default **off**, so clusters without the Prometheus Operator CRDs still render.

### Supporting
- `values.schema.json` entries, README "Observability and metrics" section, `ci-values/observability.yaml`, and CI render/assert + negative-gate steps.

## Out of scope / follow-up
Application-level alerting (e.g. a GeoServices in-band error-rate alert on `honua_geoservices_error_total`) depends on the honua-server metric being exposed, which does not exist yet. That alert is intentionally **not** shipped here rather than referencing a non-existent metric. A default Grafana dashboard is likewise deferred until the server's metric names are finalized.

## Verification
`helm lint` + `helm template` pass for `base`, all `ci-values/*` overlays (including the new `observability.yaml`), and dev/stage/prod. Rendered output parses as valid YAML (11 docs incl. ServiceMonitor + PrometheusRule). The receiver gate fails on `HONUA_OPENTELEMETRY=true` with no receiver; metrics resources do not render in the baseline.