### PR TITLE
fix(chart): writable /tmp scratch volume + default HA pod anti-affinity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,14 @@ jobs:
           grep -q 'Security__ConnectionEncryption__MasterKey:' /tmp/honua-rendered-base.yaml
           grep -q 'readiness.contract=/healthz/ready returns success after Honua startup and migrations are complete' /tmp/honua-rendered-base.yaml
 
+          # Read-only root needs a writable /tmp scratch volume by default.
+          grep -q 'mountPath: /tmp' /tmp/honua-rendered-base.yaml
+          # Single-replica baseline must not get the default anti-affinity.
+          if grep -q 'podAntiAffinity' /tmp/honua-rendered-base.yaml; then
+            echo "Single-replica baseline should not render default pod anti-affinity."
+            exit 1
+          fi
+
           grep -q 'image: "ghcr.io/honua-io/honua-server@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"' /tmp/honua-rendered-digest.yaml
           grep -q 'honua.io/image-digest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"' /tmp/honua-rendered-digest.yaml
           grep -q 'honua.io/release-id: "honua-ci-digest"' /tmp/honua-rendered-digest.yaml
@@ -131,6 +139,9 @@ jobs:
           grep -A1 'name: HONUA_PREFLIGHT_DATABASE_CHECK' /tmp/honua-rendered-base.yaml | grep -q 'value: "true"'
           grep -A1 'name: HONUA_PREFLIGHT_DATABASE_CHECK' /tmp/honua-rendered-postgresql-install.yaml | grep -q 'value: "false"'
           grep -A1 'name: HONUA_PREFLIGHT_DATABASE_CHECK' /tmp/honua-rendered-postgresql-upgrade.yaml | grep -q 'value: "true"'
+
+          # Multi-replica (autoscaling) workloads get the default soft anti-affinity.
+          grep -q 'podAntiAffinity' /tmp/honua-rendered-autoscaling-cpu.yaml
 
       - name: Assert AKS smoke overlay operator contract
         run: |

--- a/honua/README.md
+++ b/honua/README.md
@@ -372,6 +372,9 @@ characters. For non-development deployments, it also fails if
 | `preflight.timeoutSeconds` | 5 | Timeout for database and registry reachability checks. |
 | `preflight.registryCheck.enabled` | true | Check the target image registry `/v2/` endpoint before apply. |
 | `terminationGracePeriodSeconds` | 60 | Pod shutdown grace period for lock release and clean termination. |
+| `tmpVolume.enabled` | true | Mount a writable `/tmp` emptyDir. Required because `readOnlyRootFilesystem` is true and the server writes temp files; disable only if the image never writes to disk. |
+| `tmpVolume.sizeLimit` | `""` | Optional `emptyDir` size cap for `/tmp` (e.g. `1Gi`). |
+| `affinity` | `{}` | Pod affinity rules. When empty, the chart applies a soft pod anti-affinity spreading replicas across nodes for multi-replica workloads (`autoscaling.enabled` or `replicaCount > 1`). |
 | `resources` | requests `250m`/`512Mi`, limits `2`/`2Gi` | CPU/memory requests and limits. Tune for production workloads. |
 | `autoscaling.enabled` | false | Enable HPA. Requires `config.env.Deployment__Mode=MultiNode` (plus Redis and a shared cloud `FileStorage:Provider`); render fails if enabled while mode is `SingleInstance`. |
 | `autoscaling.targetCPUUtilizationPercentage` | `70` | CPU utilization threshold for scale decisions. |

--- a/honua/templates/deployment.yaml
+++ b/honua/templates/deployment.yaml
@@ -79,21 +79,49 @@ spec:
             {{- toYaml .Values.startupProbe | nindent 12 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-          {{- with .Values.extraVolumeMounts }}
+          {{- if or .Values.tmpVolume.enabled .Values.extraVolumeMounts }}
           volumeMounts:
+            {{- if .Values.tmpVolume.enabled }}
+            - name: tmp
+              mountPath: /tmp
+            {{- end }}
+            {{- with .Values.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- end }}
-      {{- with .Values.extraVolumes }}
+      {{- if or .Values.tmpVolume.enabled .Values.extraVolumes }}
       volumes:
+        {{- if .Values.tmpVolume.enabled }}
+        - name: tmp
+          {{- if .Values.tmpVolume.sizeLimit }}
+          emptyDir:
+            sizeLimit: {{ .Values.tmpVolume.sizeLimit | quote }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        {{- end }}
+        {{- with .Values.extraVolumes }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- $multiReplica := or .Values.autoscaling.enabled (gt (int .Values.replicaCount) 1) }}
+      {{- if .Values.affinity }}
       affinity:
-        {{- toYaml . | nindent 8 }}
+        {{- toYaml .Values.affinity | nindent 8 }}
+      {{- else if $multiReplica }}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchLabels:
+                    {{- include "honua.selectorLabels" . | nindent 20 }}
       {{- end }}
       {{- with .Values.tolerations }}
       tolerations:

--- a/honua/values.schema.json
+++ b/honua/values.schema.json
@@ -286,6 +286,14 @@
     "affinity": {
       "type": "object"
     },
+    "tmpVolume": {
+      "type": "object",
+      "description": "Writable /tmp emptyDir for the read-only-root container.",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "sizeLimit": { "type": "string" }
+      }
+    },
     "config": {
       "type": "object",
       "description": "Chart-managed or externally managed ConfigMap settings.",

--- a/honua/values.yaml
+++ b/honua/values.yaml
@@ -124,6 +124,16 @@ strategy:
 
 terminationGracePeriodSeconds: 60
 
+# Writable scratch volume. securityContext.readOnlyRootFilesystem is true, so the
+# container filesystem is read-only except for mounts. .NET and geospatial code
+# paths write to /tmp (temp files, shadow copies, GDAL scratch), which would hit
+# EROFS without a writable mount. This mounts an emptyDir at /tmp. Disable only
+# if you have proven the image never writes to disk.
+tmpVolume:
+  enabled: true
+  # Optional emptyDir size cap, e.g. "1Gi". Empty means no limit.
+  sizeLimit: ""
+
 preflight:
   enabled: true
   image:
@@ -179,6 +189,11 @@ nodeSelector: {}
 
 tolerations: []
 
+# Pod affinity/anti-affinity. When left empty, the chart applies a soft
+# (preferred) pod anti-affinity spreading replicas across nodes for multi-replica
+# workloads (autoscaling.enabled or replicaCount > 1), so a single node drain
+# does not take out the whole fleet or stall against the auto-rendered PDB. Set
+# an explicit affinity here to fully override that default.
 affinity: {}
 
 # Chart-managed ConfigMap. Set config.create=false and config.name to reference


### PR DESCRIPTION
## Summary

Addresses the two render-verifiable, no-cluster-needed reliability defaults from the HA-path audit. Refs #33 (partial — see checklist).

### Writable /tmp scratch volume
`securityContext.readOnlyRootFilesystem: true` made the whole container filesystem read-only, but the .NET server and geospatial code paths write to `/tmp` (temp files, GDAL scratch) — those writes hit `EROFS`. The chart now mounts a `/tmp` `emptyDir` by default, toggled by `tmpVolume.enabled` with an optional `tmpVolume.sizeLimit`.

### Default HA pod anti-affinity
When `affinity` is unset, the chart applies a soft (preferred) pod anti-affinity across `kubernetes.io/hostname` for multi-replica workloads (`autoscaling.enabled` or `replicaCount > 1`). This stops replicas from colocating, so a single node drain does not take out the fleet or stall against the auto-rendered PDB. An explicit `affinity` fully overrides it; single-replica installs are unchanged.

## Addressed from #33
- [x] `readOnlyRootFilesystem: true` with no writable `/tmp` (EROFS risk)
- [x] No default pod anti-affinity / topology spread for the HA path

## Deferred (not in this PR)
These change documented contracts or need in-cluster validation, so they are intentionally left for a separate pass rather than rushed:
- HPA memory-utilization default (CPU-only by default) — contradicts the shipped HPA tuning guidance; product/tuning decision.
- RollingUpdate `maxSurge`/`maxUnavailable` default swap — current values are asserted by CI and documented; contract decision.
- Preflight in-script retry/backoff and resources block — retry behavior is best validated against a cluster.
- preStop drain hook, readiness `failureThreshold` widening (S3).

## Verification
`helm lint` + `helm template` pass for `base`, all `ci-values/*` overlays, and dev/stage/prod. Verified: baseline (single replica) renders the `/tmp` mount and **no** anti-affinity; `replicaCount=3` and the autoscaling overlay render the soft anti-affinity; an explicit `affinity` overrides the default; `tmpVolume.enabled=false` removes the mount. Rendered output parses as valid YAML. New CI assertions cover the `/tmp` mount and the single- vs multi-replica anti-affinity behavior.