### PR TITLE
fix(chart): drainable default PDB, multi-replica SingleInstance guard, and config/secret rollout checksums

### DIFF
--- a/honua/ci-values/aks-smoke-upgrade.yaml
+++ b/honua/ci-values/aks-smoke-upgrade.yaml
@@ -1,11 +1,14 @@
 # AKS customer-operated smoke: upgrade target (honua-helm#10).
 #
 # Applied as the `helm upgrade` step after aks-smoke-install.yaml. It changes
-# release evidence metadata and scales to two replicas to exercise the upgrade
-# path the marketplace listing depends on, while keeping the migration-safe
-# Recreate strategy. Pair with scripts/aks-smoke.sh, which overrides the image
-# tag/digest and data-service endpoints for the live run.
-replicaCount: 2
+# release evidence metadata to exercise the upgrade path the marketplace listing
+# depends on, while keeping the migration-safe Recreate strategy. This overlay
+# models the SingleInstance marketplace baseline, so it stays at one replica:
+# SingleInstance with more than one replica is rejected by the chart's HA guard
+# (multi-replica HA requires Deployment__Mode=MultiNode with shared Redis and a
+# cloud FileStorage provider). Pair with scripts/aks-smoke.sh, which overrides
+# the image tag/digest and data-service endpoints for the live run.
+replicaCount: 1
 
 image:
   repository: ghcr.io/honua-io/honua-server

--- a/honua/ci-values/rolling-update.yaml
+++ b/honua/ci-values/rolling-update.yaml
@@ -1,4 +1,12 @@
 replicaCount: 2
+# Multi-replica rollout is only coherent in MultiNode mode; SingleInstance with
+# more than one replica is rejected by the chart's HA guard. This overlay renders
+# the RollingUpdate strategy across two MultiNode replicas (it already supplies
+# ConnectionStrings__redis); FileStorage is not chart-rendered so it is omitted
+# in this render-only fixture.
+config:
+  env:
+    Deployment__Mode: "MultiNode"
 strategy:
   type: RollingUpdate
   rollingUpdate:

--- a/honua/ci-values/upgrade-target.yaml
+++ b/honua/ci-values/upgrade-target.yaml
@@ -1,4 +1,10 @@
-replicaCount: 2
+# The in-cluster smoke runs the real honua-server in kind, which has no shared
+# cloud FileStorage, so it must stay SingleInstance (MultiNode rejects Local
+# storage). SingleInstance with more than one replica is rejected by the chart's
+# HA guard, so this upgrade target stays at one replica; it still exercises the
+# strategy switch to RollingUpdate, the release-metadata change, and the
+# config/secret checksum-driven rollout.
+replicaCount: 1
 image:
   pullPolicy: IfNotPresent
 strategy:

--- a/honua/templates/deployment.yaml
+++ b/honua/templates/deployment.yaml
@@ -30,6 +30,18 @@ spec:
         {{- end }}
       annotations:
         {{- include "honua.releaseAnnotations" . | nindent 8 }}
+        {{- /* Roll the pods whenever the chart-managed ConfigMap/Secret content
+               changes. These are consumed via envFrom, which Kubernetes reads
+               only at container start, so without a content checksum a
+               helm upgrade that only edits config.env or secret.env produces a
+               byte-identical Deployment, performs no rollout, and leaves pods
+               running stale config or un-rotated credentials. */ -}}
+        {{- if .Values.config.create }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if .Values.secret.create }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- end }}
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/honua/templates/pdb.yaml
+++ b/honua/templates/pdb.yaml
@@ -21,7 +21,14 @@ spec:
   {{- else if ne $maxUnavailable nil }}
   maxUnavailable: {{ $maxUnavailable }}
   {{- else }}
-  maxUnavailable: 25%
+  {{- /*
+    Default to an absolute maxUnavailable of 1 rather than a percentage.
+    Kubernetes rounds a percentage maxUnavailable DOWN, so 25% of 2-3 replicas
+    is 0, which forbids all voluntary evictions and hangs node drains -- the
+    opposite of the PDB's drain-protection intent. An absolute 1 keeps small HA
+    fleets drainable while still protecting availability.
+  */}}
+  maxUnavailable: 1
   {{- end }}
   selector:
     matchLabels:

--- a/honua/templates/validations.yaml
+++ b/honua/templates/validations.yaml
@@ -35,9 +35,17 @@
 {{- fail "release.appVersion, or Chart.AppVersion when release.appVersion is empty, must be a valid Kubernetes label value: 63 characters or less, using letters, numbers, '_', '.', or '-', and starting and ending with a letter or number." -}}
 {{- end -}}
 
+{{- /* SingleInstance cannot coordinate more than one replica. The deployment and
+       pdb templates both treat the workload as multi-replica when
+       autoscaling.enabled OR replicaCount > 1, so guard the same predicate here.
+       Previously only autoscaling.enabled was rejected, which let an operator set
+       replicaCount > 1 in the default SingleInstance mode and silently render
+       multiple uncoordinated pods behind one Service (plus auto podAntiAffinity
+       and a PDB). */ -}}
 {{- $deploymentMode := trim (default "SingleInstance" (dig "env" "Deployment__Mode" "SingleInstance" .Values.config)) -}}
-{{- if and .Values.autoscaling.enabled (eq $deploymentMode "SingleInstance") -}}
-{{- fail "autoscaling.enabled is incompatible with config.env.Deployment__Mode=SingleInstance: a single-instance server does not coordinate multiple replicas. Either set autoscaling.enabled=false and pin replicaCount: 1, or switch to horizontally scaled HA by setting config.env.Deployment__Mode=MultiNode and supplying ConnectionStrings__redis plus a shared cloud FileStorage:Provider (AwsS3 or AzureBlob; Local is rejected in MultiNode)." -}}
+{{- $multiReplica := or .Values.autoscaling.enabled (gt (int .Values.replicaCount) 1) -}}
+{{- if and $multiReplica (eq $deploymentMode "SingleInstance") -}}
+{{- fail (printf "Running more than one replica (autoscaling.enabled=%v, replicaCount=%v) is incompatible with config.env.Deployment__Mode=SingleInstance: a single-instance server does not coordinate multiple replicas. Either keep SingleInstance with autoscaling.enabled=false and replicaCount: 1, or switch to horizontally scaled HA by setting config.env.Deployment__Mode=MultiNode and supplying ConnectionStrings__redis plus a shared cloud FileStorage:Provider (AwsS3 or AzureBlob; Local is rejected in MultiNode)." .Values.autoscaling.enabled .Values.replicaCount) -}}
 {{- end -}}
 
 {{- /* The container port and all three health probes follow service.targetPort

--- a/honua/values.yaml
+++ b/honua/values.yaml
@@ -183,7 +183,9 @@ autoscaling:
 # automatically whenever the workload runs more than one pod (autoscaling.enabled
 # or replicaCount > 1); set enabled to true/false to force it on or off. Set
 # exactly one of minAvailable or maxUnavailable; when both are null the chart
-# defaults to maxUnavailable: 25%.
+# defaults to maxUnavailable: 1. (An absolute 1 is used rather than a percentage
+# because Kubernetes rounds a percentage maxUnavailable down, so 25% of 2-3
+# replicas is 0, which blocks all evictions and hangs node drains.)
 podDisruptionBudget:
   enabled: null
   minAvailable: null


### PR DESCRIPTION
## Round-1 release-audit S2 fixes

Three confirmed S2 findings for `honua-helm`, all in the core chart templates. Grouped into one PR since they are small, related correctness/operability fixes to the same Deployment + supporting templates.

### Findings addressed

1. **`honua/templates/pdb.yaml:24` (correctness)** — Auto-rendered PDB defaulted to `maxUnavailable: 25%`. Kubernetes rounds a percentage `maxUnavailable` DOWN, so 25% of 2-3 replicas = 0, which forbids all voluntary evictions and hangs node drains — the opposite of the PDB's drain-protection intent. Only 4+ replicas got a non-zero allowance. **Fix:** default to an absolute `maxUnavailable: 1` so small HA fleets stay drainable. Explicit `minAvailable`/`maxUnavailable` overrides are unchanged. (values.yaml doc comment updated.)

2. **`honua/templates/validations.yaml:39` (correctness)** — The guardrail failed render only for `autoscaling.enabled` + `SingleInstance`, but `replicaCount > 1` + the default `SingleInstance` rendered fine, producing multiple uncoordinated pods behind one Service (plus auto podAntiAffinity and a PDB). **Fix:** fail for the same multi-replica predicate (`autoscaling.enabled OR replicaCount > 1`) that the deployment and pdb templates already compute; error message reports both inputs.

3. **`honua/templates/deployment.yaml:31` (reliability/operability + coherence)** — Pod-template annotations derived only from `releaseAnnotations` + user `podAnnotations`; none from config/secret content. Because `config.env`/`secret.env` are consumed via `envFrom` (read only at container start), a `helm upgrade` editing only config or a rotated secret produced a byte-identical Deployment, performed **no rollout**, and left pods on stale config / un-rotated credentials. **Fix:** add `checksum/config` and `checksum/secret` pod-template annotations computed from the rendered ConfigMap/Secret (guarded by `config.create` / `secret.create`), so config and credential changes propagate. (Covers both the reliability and coherence findings, which are the same defect.)

### Verification

- `helm dependency build` + `helm lint` (base, dev, stage overlays) pass. (`values-prod.yaml` lint failure is pre-existing and unrelated — that overlay intentionally omits `image.tag`/`image.digest`, which the release pipeline stamps.)
- `helm template` confirmed: PDB renders `maxUnavailable: 1` for multi-replica MultiNode and autoscaled installs; explicit `podDisruptionBudget.maxUnavailable` override still honored.
- `replicaCount=3` + `SingleInstance` now fails render; `autoscaling.enabled` + `SingleInstance` still fails; default `replicaCount=1` install renders cleanly.
- `checksum/config` and `checksum/secret` change when `config.env` / `secret.env` change; `checksum/secret` is omitted when `secret.create=false` (external secret).
