### PR TITLE
fix(chart): CPU-only HPA default and resilient preflight reachability probes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,8 +158,22 @@ jobs:
           grep -A1 'name: HONUA_PREFLIGHT_DATABASE_CHECK' /tmp/honua-rendered-postgresql-install.yaml | grep -q 'value: "false"'
           grep -A1 'name: HONUA_PREFLIGHT_DATABASE_CHECK' /tmp/honua-rendered-postgresql-upgrade.yaml | grep -q 'value: "true"'
 
+          # The preflight hook retries reachability probes in-script (backoffLimit
+          # is 0), so the retry env must be wired into the Job.
+          grep -q 'name: HONUA_PREFLIGHT_RETRIES' /tmp/honua-rendered-base.yaml
+          grep -q 'name: HONUA_PREFLIGHT_RETRY_DELAY_SECONDS' /tmp/honua-rendered-base.yaml
+
           # Multi-replica (autoscaling) workloads get the default soft anti-affinity.
           grep -q 'podAntiAffinity' /tmp/honua-rendered-autoscaling-cpu.yaml
+
+          # Memory-based autoscaling is off by default: with only CPU configured
+          # (autoscaling-cpu.yaml leaves the memory target unset) the HPA renders
+          # a cpu metric and no memory metric.
+          grep -q 'name: cpu' /tmp/honua-rendered-autoscaling-cpu.yaml
+          if grep -q 'name: memory' /tmp/honua-rendered-autoscaling-cpu.yaml; then
+            echo "HPA must not render a memory metric when targetMemoryUtilizationPercentage defaults to 0."
+            exit 1
+          fi
 
       - name: Assert AKS smoke overlay operator contract
         run: |

--- a/honua/README.md
+++ b/honua/README.md
@@ -137,7 +137,11 @@ autoscaling:
   minReplicas: 2
   maxReplicas: 20
   targetCPUUtilizationPercentage: 70
-  targetMemoryUtilizationPercentage: 80
+  # Memory scaling is off by default (0). The .NET server-GC heap rarely returns
+  # committed memory to the OS, so a memory target tends to peg replicas at
+  # maxReplicas and never scale down. Set this > 0 only after confirming memory
+  # tracks load for your workload.
+  targetMemoryUtilizationPercentage: 0
   behavior:
     scaleUp:
       stabilizationWindowSeconds: 60
@@ -385,6 +389,8 @@ characters. For non-development deployments, it also fails if
 | `strategy.rollingUpdate` | `maxSurge: 0`, `maxUnavailable: 1` | RollingUpdate settings used only when `strategy.type=RollingUpdate`; both values cannot be zero. |
 | `preflight.enabled` | true | Enable pre-install/pre-upgrade validation hook. |
 | `preflight.timeoutSeconds` | 5 | Timeout for database and registry reachability checks. |
+| `preflight.retries` | 3 | Attempts per reachability probe (database/Redis/registry) before the hook fails. The hook runs with `backoffLimit: 0`, so in-script retries absorb transient DNS/egress/registry blips. Set to 1 to disable. |
+| `preflight.retryDelaySeconds` | 3 | Delay between preflight reachability probe attempts. |
 | `preflight.registryCheck.enabled` | true | Check the target image registry `/v2/` endpoint before apply. |
 | `terminationGracePeriodSeconds` | 60 | Pod shutdown grace period for lock release and clean termination. |
 | `tmpVolume.enabled` | true | Mount a writable `/tmp` emptyDir. Required because `readOnlyRootFilesystem` is true and the server writes temp files; disable only if the image never writes to disk. |
@@ -393,7 +399,7 @@ characters. For non-development deployments, it also fails if
 | `resources` | requests `250m`/`512Mi`, limits `2`/`2Gi` | CPU/memory requests and limits. Tune for production workloads. |
 | `autoscaling.enabled` | false | Enable HPA. Requires `config.env.Deployment__Mode=MultiNode` (plus Redis and a shared cloud `FileStorage:Provider`); render fails if enabled while mode is `SingleInstance`. |
 | `autoscaling.targetCPUUtilizationPercentage` | `70` | CPU utilization threshold for scale decisions. |
-| `autoscaling.targetMemoryUtilizationPercentage` | `80` | Memory utilization threshold for scale decisions. |
+| `autoscaling.targetMemoryUtilizationPercentage` | `0` | Memory utilization threshold. `0` disables memory-based scaling (the default), because the .NET server-GC heap rarely releases committed memory and a memory target tends to peg replicas at `maxReplicas`. Opt in (`> 0`) only after confirming memory tracks load. |
 | `autoscaling.behavior` | scale up/down policies | autoscaling/v2 behavior policies and stabilization windows. |
 | `podDisruptionBudget.enabled` | `null` | Render a PodDisruptionBudget. `null` auto-enables it for multi-replica workloads (`autoscaling.enabled` or `replicaCount > 1`); set `true`/`false` to force. |
 | `podDisruptionBudget.minAvailable` | `null` | Minimum available pods during voluntary disruptions. Mutually exclusive with `maxUnavailable`. |
@@ -486,13 +492,20 @@ alert) are added once the server exposes the corresponding metric.
 
 The default HPA thresholds are tuned for mixed geospatial workloads:
 - `targetCPUUtilizationPercentage: 70` for CPU-heavy spatial predicates and tile generation.
-- `targetMemoryUtilizationPercentage: 80` for bursty map rendering and large feature payloads.
+- `targetMemoryUtilizationPercentage: 0` (memory scaling off) by default. The .NET
+  server-GC heap holds onto committed memory and rarely releases it to the OS, so a
+  memory utilization target tends to ratchet replicas up to `maxReplicas` and never
+  scale them back down, defeating elastic scale-down. Scale on CPU and opt into
+  memory scaling deliberately (see below).
 - `scaleUp` stabilization of 60s with 50% growth to react quickly to traffic ramps.
 - `scaleDown` stabilization of 300s with 10% shrink to avoid thrash after short spikes.
 
 For dataset-specific tuning:
 - Increase `maxReplicas` only after validating PostgreSQL connection limits.
-- Raise memory targets (for example 85-90) if large map exports are common and pod OOM is not observed.
+- Enable memory-based scaling (`targetMemoryUtilizationPercentage` > 0, for example
+  80-90) only if large map exports are common, the workload's memory actually
+  tracks load, and you have confirmed it scales back down rather than pegging at
+  `maxReplicas`.
 - Reduce `scaleDown` aggressiveness further for workloads with repeated 3-10 minute query bursts.
 
 ## Local validation

--- a/honua/ci-values/autoscaling-cpu.yaml
+++ b/honua/ci-values/autoscaling-cpu.yaml
@@ -6,10 +6,12 @@ secret:
     ConnectionStrings__redis: "redis:6379,password=ci-redis-password"
 # Autoscaling (horizontal scale-out) is only coherent under MultiNode mode, which
 # also requires Redis (above) and a shared cloud FileStorage provider at runtime.
+# This overlay intentionally leaves targetMemoryUtilizationPercentage unset to
+# exercise the chart default (memory scaling OFF), so the HPA renders a CPU
+# metric only.
 config:
   env:
     Deployment__Mode: "MultiNode"
 autoscaling:
   enabled: true
   targetCPUUtilizationPercentage: 70
-  targetMemoryUtilizationPercentage: 0

--- a/honua/templates/preflight-job.yaml
+++ b/honua/templates/preflight-job.yaml
@@ -38,6 +38,10 @@ spec:
           env:
             - name: HONUA_PREFLIGHT_TIMEOUT_SECONDS
               value: {{ .Values.preflight.timeoutSeconds | quote }}
+            - name: HONUA_PREFLIGHT_RETRIES
+              value: {{ .Values.preflight.retries | default 3 | quote }}
+            - name: HONUA_PREFLIGHT_RETRY_DELAY_SECONDS
+              value: {{ .Values.preflight.retryDelaySeconds | default 3 | quote }}
             - name: HONUA_PREFLIGHT_REGISTRY_CHECK
               value: {{ ternary "true" "false" .Values.preflight.registryCheck.enabled | quote }}
             - name: HONUA_PREFLIGHT_DATABASE_CHECK
@@ -70,6 +74,55 @@ spec:
               fail() {
                 echo "preflight failed: $*" >&2
                 exit 1
+              }
+
+              # Retry a check command with a fixed backoff. The hook runs with
+              # backoffLimit: 0, so without in-script retries a single transient
+              # DNS/egress/registry blip would abort the whole install/upgrade and
+              # trigger a rollback. Reachability probes are retried up to
+              # HONUA_PREFLIGHT_RETRIES times before the hook gives up.
+              retry() {
+                attempts="${HONUA_PREFLIGHT_RETRIES:-1}"
+                [ "${attempts}" -ge 1 ] || attempts=1
+                delay="${HONUA_PREFLIGHT_RETRY_DELAY_SECONDS:-0}"
+                i=1
+                while true; do
+                  if "$@"; then
+                    return 0
+                  fi
+                  if [ "${i}" -ge "${attempts}" ]; then
+                    return 1
+                  fi
+                  echo "  attempt ${i}/${attempts} failed; retrying in ${delay}s" >&2
+                  sleep "${delay}"
+                  i=$((i + 1))
+                done
+              }
+
+              # TCP reachability probe via curl. Connect-level success and
+              # protocol-level responses (curl exits 0/1/52/56) all prove the
+              # endpoint is reachable; any other exit means unreachable.
+              tcp_reachable() {
+                set +e
+                curl --silent --show-error --connect-timeout "${HONUA_PREFLIGHT_TIMEOUT_SECONDS}" --max-time "${HONUA_PREFLIGHT_TIMEOUT_SECONDS}" "http://$1:$2/" >/dev/null 2>&1
+                _status=$?
+                set -e
+                case "${_status}" in
+                  0|1|52|56)
+                    return 0
+                    ;;
+                  *)
+                    return 1
+                    ;;
+                esac
+              }
+
+              registry_reachable() {
+                set +e
+                curl --silent --show-error --connect-timeout "${HONUA_PREFLIGHT_TIMEOUT_SECONDS}" --max-time "${HONUA_PREFLIGHT_TIMEOUT_SECONDS}" -o /dev/null "https://${HONUA_PREFLIGHT_REGISTRY_HOST}/v2/"
+                _status=$?
+                set -e
+                return "${_status}"
               }
 
               for var in ConnectionStrings__DefaultConnection HONUA_ADMIN_PASSWORD Security__ConnectionEncryption__MasterKey; do
@@ -142,17 +195,9 @@ spec:
                 fi
 
                 echo "Checking PostgreSQL TCP reachability at ${db_host}:${db_port}"
-                set +e
-                curl --silent --show-error --connect-timeout "${HONUA_PREFLIGHT_TIMEOUT_SECONDS}" --max-time "${HONUA_PREFLIGHT_TIMEOUT_SECONDS}" "http://${db_host}:${db_port}/" >/dev/null
-                db_status=$?
-                set -e
-                case "$db_status" in
-                  0|1|52|56)
-                    ;;
-                  *)
-                    fail "database endpoint ${db_host}:${db_port} is not reachable (curl exit ${db_status})"
-                    ;;
-                esac
+                if ! retry tcp_reachable "${db_host}" "${db_port}"; then
+                  fail "database endpoint ${db_host}:${db_port} is not reachable after ${HONUA_PREFLIGHT_RETRIES} attempt(s)"
+                fi
               else
                 echo "Skipping PostgreSQL TCP reachability check during initial chart-managed PostgreSQL install; pre-upgrade checks run after PostgreSQL exists."
               fi
@@ -181,17 +226,9 @@ spec:
                   fi
 
                   echo "Checking Redis TCP reachability at ${redis_host}:${redis_port}"
-                  set +e
-                  curl --silent --show-error --connect-timeout "${HONUA_PREFLIGHT_TIMEOUT_SECONDS}" --max-time "${HONUA_PREFLIGHT_TIMEOUT_SECONDS}" "http://${redis_host}:${redis_port}/" >/dev/null
-                  redis_status=$?
-                  set -e
-                  case "$redis_status" in
-                    0|1|52|56)
-                      ;;
-                    *)
-                      fail "Redis endpoint ${redis_host}:${redis_port} is not reachable (curl exit ${redis_status})"
-                      ;;
-                  esac
+                  if ! retry tcp_reachable "${redis_host}" "${redis_port}"; then
+                    fail "Redis endpoint ${redis_host}:${redis_port} is not reachable after ${HONUA_PREFLIGHT_RETRIES} attempt(s)"
+                  fi
                 else
                   echo "Skipping Redis TCP reachability check during initial chart-managed Redis install; pre-upgrade checks run after Redis exists."
                 fi
@@ -199,12 +236,8 @@ spec:
 
               if [ "${HONUA_PREFLIGHT_REGISTRY_CHECK}" = "true" ]; then
                 echo "Checking image registry reachability at ${HONUA_PREFLIGHT_REGISTRY_HOST} for ${HONUA_IMAGE_REFERENCE}"
-                set +e
-                curl --silent --show-error --connect-timeout "${HONUA_PREFLIGHT_TIMEOUT_SECONDS}" --max-time "${HONUA_PREFLIGHT_TIMEOUT_SECONDS}" -o /dev/null "https://${HONUA_PREFLIGHT_REGISTRY_HOST}/v2/"
-                registry_status=$?
-                set -e
-                if [ "$registry_status" -ne 0 ]; then
-                  fail "image registry ${HONUA_PREFLIGHT_REGISTRY_HOST} is not reachable (curl exit ${registry_status})"
+                if ! retry registry_reachable; then
+                  fail "image registry ${HONUA_PREFLIGHT_REGISTRY_HOST} is not reachable after ${HONUA_PREFLIGHT_RETRIES} attempt(s)"
                 fi
               else
                 echo "Skipping image registry reachability check; kubelet image pull remains authoritative."

--- a/honua/values.schema.json
+++ b/honua/values.schema.json
@@ -93,6 +93,18 @@
           "minimum": 1,
           "maximum": 30
         },
+        "retries": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 10,
+          "description": "Attempts per reachability probe before the preflight hook fails."
+        },
+        "retryDelaySeconds": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 60,
+          "description": "Delay between preflight reachability probe attempts."
+        },
         "image": {
           "type": "object",
           "properties": {

--- a/honua/values.yaml
+++ b/honua/values.yaml
@@ -145,11 +145,27 @@ preflight:
     tag: "8.5.0"
     pullPolicy: IfNotPresent
   timeoutSeconds: 5
+  # The preflight hook runs with backoffLimit: 0 (a single Pod attempt), so a
+  # transient DNS/egress/registry blip during the probe would abort the whole
+  # install/upgrade. To absorb such blips, each reachability probe (database,
+  # Redis, registry) is retried in-script up to `retries` times with
+  # `retryDelaySeconds` between attempts before the hook fails. Set retries to 1
+  # to disable retrying.
+  retries: 3
+  retryDelaySeconds: 3
   registryCheck:
     enabled: true
 
 # HorizontalPodAutoscaler. When enabled, at least one target utilization value
 # must be greater than 0; the chart validates this at render time.
+#
+# Memory-based autoscaling is OFF by default (targetMemoryUtilizationPercentage:
+# 0). The .NET server-GC heap holds onto committed memory and rarely releases it
+# back to the OS, so a memory utilization target tends to ratchet replicas up to
+# maxReplicas and then never scale them back down -- defeating elastic
+# scale-down. Default to CPU-only scaling and opt into memory scaling
+# deliberately (set targetMemoryUtilizationPercentage > 0) only after confirming
+# the workload's memory actually tracks load.
 #
 # Horizontal scale-out is only coherent in MultiNode mode. The chart fails at
 # render time if autoscaling.enabled is true while
@@ -162,7 +178,7 @@ autoscaling:
   minReplicas: 2
   maxReplicas: 20
   targetCPUUtilizationPercentage: 70
-  targetMemoryUtilizationPercentage: 80
+  targetMemoryUtilizationPercentage: 0
   behavior:
     scaleUp:
       stabilizationWindowSeconds: 60


### PR DESCRIPTION
## Summary

Completes the remaining render-verifiable reliability/operability defaults from the HA-path audit. The `/tmp` scratch volume and default pod anti-affinity (the other two S2 items) landed earlier in #41; this PR finishes the rest.

### CPU-only HPA default (memory scaling opt-in)
The .NET server-GC heap holds onto committed memory and rarely releases it back to the OS, so a default memory-utilization target ratchets replicas up to `maxReplicas` and never scales them back down, defeating elastic scale-down. `autoscaling.targetMemoryUtilizationPercentage` now defaults to `0` (CPU-only); memory scaling is opt-in. `autoscaling-cpu.yaml` leaves the memory target unset so CI exercises the new default and asserts the HPA renders a `cpu` metric and no `memory` metric. README reference table and the geospatial HPA tuning guidance are updated to match.

### Resilient preflight reachability probes
The preflight hook runs with `backoffLimit: 0` (a single Pod attempt), so a transient DNS/egress/registry blip during a reachability probe aborted the whole install/upgrade and triggered a rollback. Each probe (database, Redis, registry) is now retried in-script via a `retry()` helper with fixed backoff, configurable through `preflight.retries` (default 3) and `preflight.retryDelaySeconds` (default 3); set `retries: 1` to disable. The probe bodies are factored into `tcp_reachable` / `registry_reachable` helpers. CI asserts the retry env is wired into the Job.

## Verification
- `helm lint` passes for base, dev, stage, and prod (`--set image.tag`).
- `helm template` renders cleanly for every `ci-values/*` overlay and dev/stage/prod.
- `autoscaling-cpu` renders a `cpu` HPA metric and **no** `memory` metric.
- The rendered preflight script passes `sh -n`; the `retry()` logic was unit-checked (succeeds on a later attempt, gives up after the configured count).

## Closes
Closes #33

The remaining items on #33 are all **S3** (out of the high/medium scope) and are intentionally deferred: `registryCheck.enabled` default flip, value-gated `preStop` drain hook, readiness `failureThreshold` widening, a preflight resources block, and the RollingUpdate `maxSurge`/`maxUnavailable` default swap (the latter is asserted by CI and changes a documented contract).
