### PR TITLE
refactor(chart): consolidate validation into one layer and cover complexity guards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,6 +261,38 @@ jobs:
             exit 1
           fi
 
+      - name: Validate digest-format guard fails malformed digest
+        run: |
+          set +e
+          helm template honua ./honua \
+            -f honua/ci-values/base.yaml \
+            --set image.tag="" \
+            --set image.pullPolicy=IfNotPresent \
+            --set-string image.digest=sha256:not-a-valid-digest \
+            > /tmp/honua-rendered-digest-format-invalid.yaml 2>&1
+          status=$?
+          set -e
+          if [[ "${status}" -eq 0 ]]; then
+            echo "Expected malformed image.digest render to fail."
+            cat /tmp/honua-rendered-digest-format-invalid.yaml
+            exit 1
+          fi
+
+      - name: Validate release.id label guard fails invalid config
+        run: |
+          set +e
+          helm template honua ./honua \
+            -f honua/ci-values/base.yaml \
+            --set-string release.id='Invalid Release Id!' \
+            > /tmp/honua-rendered-release-id-invalid.yaml 2>&1
+          status=$?
+          set -e
+          if [[ "${status}" -eq 0 ]]; then
+            echo "Expected invalid release.id render to fail."
+            cat /tmp/honua-rendered-release-id-invalid.yaml
+            exit 1
+          fi
+
       - name: Validate prod overlay requires an explicit image pin
         run: |
           set +e
@@ -351,21 +383,47 @@ jobs:
             cat /tmp/honua-rendered-master-key-invalid.yaml
             exit 1
           fi
+          grep -q "Security__ConnectionEncryption__MasterKey must be at least 32 characters long" \
+            /tmp/honua-rendered-master-key-invalid.yaml
 
-      - name: Validate admin password guard fails invalid config
+      # Each fixture is 16+ characters so it clears the length check and isolates
+      # exactly one complexity rule; assert the specific failure message so the
+      # individual guards (not just the length short-circuit) are exercised.
+      - name: Validate admin password complexity guards fail invalid configs
         run: |
-          set +e
-          helm template honua ./honua \
-            -f honua/ci-values/base.yaml \
-            --set secret.env.HONUA_ADMIN_PASSWORD=weakpassword \
-            > /tmp/honua-rendered-admin-password-invalid.yaml 2>&1
-          status=$?
-          set -e
-          if [[ "${status}" -eq 0 ]]; then
-            echo "Expected weak HONUA_ADMIN_PASSWORD render to fail."
-            cat /tmp/honua-rendered-admin-password-invalid.yaml
-            exit 1
-          fi
+          set -euo pipefail
+          assert_admin_pw_fails() {
+            password="$1"
+            expected="$2"
+            set +e
+            out=$(helm template honua ./honua \
+              -f honua/ci-values/base.yaml \
+              --set-string "secret.env.HONUA_ADMIN_PASSWORD=${password}" 2>&1)
+            status=$?
+            set -e
+            if [[ "${status}" -eq 0 ]]; then
+              echo "Expected HONUA_ADMIN_PASSWORD '${password}' to fail render."
+              echo "${out}"
+              exit 1
+            fi
+            if ! echo "${out}" | grep -q "${expected}"; then
+              echo "Expected failure message: ${expected}"
+              echo "Got: ${out}"
+              exit 1
+            fi
+          }
+          # Too short (length check).
+          assert_admin_pw_fails 'Weak1!' \
+            "HONUA_ADMIN_PASSWORD must be at least 16 characters long"
+          # 16+ chars, each missing exactly one required character class.
+          assert_admin_pw_fails 'ciadminpassword1!' \
+            "HONUA_ADMIN_PASSWORD must contain at least one uppercase letter"
+          assert_admin_pw_fails 'CIADMINPASSWORD1!' \
+            "HONUA_ADMIN_PASSWORD must contain at least one lowercase letter"
+          assert_admin_pw_fails 'CiAdminPasswordX!' \
+            "HONUA_ADMIN_PASSWORD must contain at least one digit"
+          assert_admin_pw_fails 'CiAdminPassword12' \
+            "HONUA_ADMIN_PASSWORD must contain at least one special character"
 
       - name: Validate Redis connection guard fails invalid config
         run: |

--- a/honua/templates/_helpers.tpl
+++ b/honua/templates/_helpers.tpl
@@ -164,13 +164,65 @@ true
 {{- printf "%s-release-info" (include "honua.fullname" .) -}}
 {{- end -}}
 
+{{- /* Minimum credential lengths, defined once so the render-time validation
+       layer has a single source of truth for the thresholds. The preflight Job
+       (templates/preflight-job.yaml) enforces the same minimums at install time
+       for externally-managed secrets the chart cannot see at render time; keep
+       the two in sync. */ -}}
+{{- define "honua.minAdminPasswordLength" -}}16{{- end -}}
+{{- define "honua.minMasterKeyLength" -}}32{{- end -}}
+
+{{- /* Copy non-empty, non-nil string values from the "src" env dict into the
+       "dst" dict, then render nothing. Helm passes dicts by reference, so this
+       mutates dst in place. Shared by configmap.yaml and honua.secretData so the
+       empty-stripping rule is defined once. */ -}}
+{{- define "honua.nonEmptyEnv" -}}
+{{- $src := .src | default dict -}}
+{{- $dst := .dst -}}
+{{- range $key, $value := $src }}
+{{- if and (ne (toString $value) "") (ne (toString $value) "<nil>") }}
+{{- $_ := set $dst $key (toString $value) }}
+{{- end }}
+{{- end }}
+{{- end -}}
+
+{{- /* Authoritative complexity/length policy for chart-managed secret
+       credentials. Invoked from templates/validations.yaml (the validation
+       layer) rather than from Secret rendering, so the policy is no longer
+       welded to honua.secretData. Only runs for values the chart can see
+       (secret.create=true); externally-managed secrets are validated at install
+       time by the preflight Job. */ -}}
+{{- define "honua.validateSecretComplexity" -}}
+{{- $minPassword := int (include "honua.minAdminPasswordLength" .) -}}
+{{- $minMasterKey := int (include "honua.minMasterKeyLength" .) -}}
+{{- $secretEnv := get (.Values.secret | default dict) "env" | default dict -}}
+{{- $adminPassword := toString (default "" (get $secretEnv "HONUA_ADMIN_PASSWORD")) -}}
+{{- if $adminPassword -}}
+{{- if lt (len $adminPassword) $minPassword -}}
+{{- fail (printf "secret.env.HONUA_ADMIN_PASSWORD must be at least %d characters long." $minPassword) -}}
+{{- end -}}
+{{- if not (regexMatch "[A-Z]" $adminPassword) -}}
+{{- fail "secret.env.HONUA_ADMIN_PASSWORD must contain at least one uppercase letter." -}}
+{{- end -}}
+{{- if not (regexMatch "[a-z]" $adminPassword) -}}
+{{- fail "secret.env.HONUA_ADMIN_PASSWORD must contain at least one lowercase letter." -}}
+{{- end -}}
+{{- if not (regexMatch "[0-9]" $adminPassword) -}}
+{{- fail "secret.env.HONUA_ADMIN_PASSWORD must contain at least one digit." -}}
+{{- end -}}
+{{- if not (regexMatch "[^A-Za-z0-9]" $adminPassword) -}}
+{{- fail "secret.env.HONUA_ADMIN_PASSWORD must contain at least one special character." -}}
+{{- end -}}
+{{- end -}}
+{{- $masterKey := toString (default "" (get $secretEnv "Security__ConnectionEncryption__MasterKey")) -}}
+{{- if and $masterKey (lt (len $masterKey) $minMasterKey) -}}
+{{- fail (printf "secret.env.Security__ConnectionEncryption__MasterKey must be at least %d characters long." $minMasterKey) -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "honua.secretData" -}}
 {{- $data := dict -}}
-{{- range $key, $value := .Values.secret.env }}
-{{- if and (ne (toString $value) "") (ne (toString $value) "<nil>") }}
-{{- $_ := set $data $key (toString $value) }}
-{{- end }}
-{{- end }}
+{{- include "honua.nonEmptyEnv" (dict "src" .Values.secret.env "dst" $data) -}}
 {{- if and (not (hasKey $data "ConnectionStrings__DefaultConnection")) .Values.postgresql.enabled }}
 {{- $pgHost := include "honua.postgresqlHost" . }}
 {{- $pgPort := include "honua.postgresqlPort" . }}
@@ -195,29 +247,13 @@ true
 {{- end }}
 {{- if not (hasKey $data "HONUA_ADMIN_PASSWORD") }}
 {{- required "secret.env.HONUA_ADMIN_PASSWORD is required. Set it to a strong admin password." .Values.secret.env.HONUA_ADMIN_PASSWORD }}
-{{- else -}}
-{{- $adminPassword := get $data "HONUA_ADMIN_PASSWORD" | toString -}}
-{{- if lt (len $adminPassword) 16 }}
-{{- fail "secret.env.HONUA_ADMIN_PASSWORD must be at least 16 characters long." }}
-{{- end }}
-{{- if not (regexMatch "[A-Z]" $adminPassword) }}
-{{- fail "secret.env.HONUA_ADMIN_PASSWORD must contain at least one uppercase letter." }}
-{{- end }}
-{{- if not (regexMatch "[a-z]" $adminPassword) }}
-{{- fail "secret.env.HONUA_ADMIN_PASSWORD must contain at least one lowercase letter." }}
-{{- end }}
-{{- if not (regexMatch "[0-9]" $adminPassword) }}
-{{- fail "secret.env.HONUA_ADMIN_PASSWORD must contain at least one digit." }}
-{{- end }}
-{{- if not (regexMatch "[^A-Za-z0-9]" $adminPassword) }}
-{{- fail "secret.env.HONUA_ADMIN_PASSWORD must contain at least one special character." }}
-{{- end }}
 {{- end }}
 {{- if not (hasKey $data "Security__ConnectionEncryption__MasterKey") }}
 {{- required "secret.env.Security__ConnectionEncryption__MasterKey is required. Set it to a secure random string of at least 32 characters." .Values.secret.env.Security__ConnectionEncryption__MasterKey }}
-{{- else if lt (len (get $data "Security__ConnectionEncryption__MasterKey" | toString)) 32 }}
-{{- fail "secret.env.Security__ConnectionEncryption__MasterKey must be at least 32 characters long." }}
 {{- end }}
+{{- /* Credential complexity/length policy lives in honua.validateSecretComplexity
+       and is enforced from templates/validations.yaml; this helper only resolves
+       and renders the Secret payload. */ -}}
 {{- range $key := keys $data | sortAlpha }}
 {{ $key }}: {{ get $data $key | toString | b64enc }}
 {{- end }}

--- a/honua/templates/configmap.yaml
+++ b/honua/templates/configmap.yaml
@@ -1,10 +1,6 @@
 {{- if .Values.config.create }}
 {{- $data := dict }}
-{{- range $key, $value := .Values.config.env }}
-{{- if and (ne (toString $value) "") (ne (toString $value) "<nil>") }}
-{{- $_ := set $data $key (toString $value) }}
-{{- end }}
-{{- end }}
+{{- include "honua.nonEmptyEnv" (dict "src" .Values.config.env "dst" $data) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/honua/templates/hpa.yaml
+++ b/honua/templates/hpa.yaml
@@ -1,9 +1,9 @@
 {{- if .Values.autoscaling.enabled }}
+{{- /* Cross-field guard (at least one utilization target > 0) lives in
+       templates/validations.yaml. These booleans only select which metrics to
+       render. */ -}}
 {{- $hasCPU := gt (int (default 0 .Values.autoscaling.targetCPUUtilizationPercentage)) 0 }}
 {{- $hasMemory := gt (int (default 0 .Values.autoscaling.targetMemoryUtilizationPercentage)) 0 }}
-{{- if not (or $hasCPU $hasMemory) }}
-{{- fail "autoscaling.enabled requires targetCPUUtilizationPercentage and/or targetMemoryUtilizationPercentage greater than 0" }}
-{{- end }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:

--- a/honua/templates/pdb.yaml
+++ b/honua/templates/pdb.yaml
@@ -11,11 +11,11 @@ metadata:
     {{- include "honua.labels" . | nindent 4 }}
     {{- include "honua.releaseLabels" . | nindent 4 }}
 spec:
+  {{- /* The minAvailable/maxUnavailable mutual-exclusion guard lives in
+         templates/validations.yaml; this template only selects which field to
+         render. */ -}}
   {{- $minAvailable := dig "minAvailable" nil $pdb -}}
   {{- $maxUnavailable := dig "maxUnavailable" nil $pdb -}}
-  {{- if and (ne $minAvailable nil) (ne $maxUnavailable nil) }}
-  {{- fail "Set only one of podDisruptionBudget.minAvailable or podDisruptionBudget.maxUnavailable, not both." }}
-  {{- end }}
   {{- if ne $minAvailable nil }}
   minAvailable: {{ $minAvailable }}
   {{- else if ne $maxUnavailable nil }}

--- a/honua/templates/validations.yaml
+++ b/honua/templates/validations.yaml
@@ -1,3 +1,21 @@
+{{- /*
+  Single validation layer for the chart's cross-field / render-time guards.
+
+  Division of responsibility with values.schema.json:
+    * values.schema.json owns structural validation -- types, enums, patterns,
+      min/max, and the JSON-Schema conditional rules (image tag XOR digest,
+      digest pattern, pullPolicy-with-digest, RollingUpdate non-zero budget,
+      autoscaling target presence, secret/redis/postgresql requirements). It is
+      the first gate and produces schema-level errors.
+    * This file owns cross-field render-time checks that JSON Schema cannot
+      express well, plus operator-friendly failure messages. Where a rule is
+      intentionally enforced in BOTH places (e.g. image tag/digest, the digest
+      pattern, autoscaling target presence) the schema is the early structural
+      gate and the guard here is the explanatory backstop; keep the two aligned.
+
+  All chart-wide fail-based guards belong here rather than scattered across the
+  individual resource templates.
+*/ -}}
 {{- $secretName := trim (default "" .Values.secret.name) -}}
 {{- $hasSecretName := gt (len $secretName) 0 -}}
 {{- $hasExtraEnvFrom := gt (len .Values.extraEnvFrom) 0 -}}
@@ -98,4 +116,31 @@
 {{- if not (or $hasOtlp $hasServiceMonitor $hasScrapeAnnotations) -}}
 {{- fail "config.env.HONUA_OPENTELEMETRY/HONUA_OBSERVABILITY is enabled but no telemetry receiver is configured. Set observability.otlpEndpoint to an OpenTelemetry collector, or enable metrics.serviceMonitor.enabled / metrics.serviceAnnotations.enabled. Otherwise disable observability so the deployment is not blind." -}}
 {{- end -}}
+{{- end -}}
+
+{{- /* Autoscaling requires at least one positive target utilization. Moved here
+       from hpa.yaml so the cross-field guard lives in the validation layer; the
+       schema also requires this for autoscaling.enabled=true. */ -}}
+{{- if .Values.autoscaling.enabled -}}
+{{- $hasCPU := gt (int (default 0 .Values.autoscaling.targetCPUUtilizationPercentage)) 0 -}}
+{{- $hasMemory := gt (int (default 0 .Values.autoscaling.targetMemoryUtilizationPercentage)) 0 -}}
+{{- if not (or $hasCPU $hasMemory) -}}
+{{- fail "autoscaling.enabled requires targetCPUUtilizationPercentage and/or targetMemoryUtilizationPercentage greater than 0" -}}
+{{- end -}}
+{{- end -}}
+
+{{- /* A PodDisruptionBudget accepts exactly one of minAvailable/maxUnavailable.
+       Moved here from pdb.yaml so the cross-field guard lives in the validation
+       layer. */ -}}
+{{- $pdb := .Values.podDisruptionBudget | default dict -}}
+{{- if and (ne (dig "minAvailable" nil $pdb) nil) (ne (dig "maxUnavailable" nil $pdb) nil) -}}
+{{- fail "Set only one of podDisruptionBudget.minAvailable or podDisruptionBudget.maxUnavailable, not both." -}}
+{{- end -}}
+
+{{- /* Chart-managed secret credential complexity/length policy. Enforced here in
+       the validation layer (was previously welded to honua.secretData). Only the
+       values the chart can see are checked; externally-managed secrets are
+       validated at install time by the preflight Job. */ -}}
+{{- if .Values.secret.create -}}
+{{- include "honua.validateSecretComplexity" . -}}
 {{- end -}}

--- a/honua/values.schema.json
+++ b/honua/values.schema.json
@@ -2,6 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "description": "Values contract for the Honua Server Helm chart.",
+  "$comment": "This schema owns structural validation: types, enums, patterns, min/max, and the conditional rules in allOf (image tag XOR digest, digest pattern, pullPolicy-with-digest, RollingUpdate non-zero budget, autoscaling target presence, secret/redis/postgresql requirements). Cross-field render-time guards and operator-friendly failure messages live in templates/validations.yaml. Where a rule appears in both places it is enforced structurally here and explained there; keep the two aligned.",
   "properties": {
     "replicaCount": {
       "type": "integer",


### PR DESCRIPTION
## Summary

Maintainability hardening for the validation/helper architecture audit. The chart encoded the same contracts in several places, scattered cross-field guards across resource templates, welded credential policy to Secret rendering, and its admin-password negative test short-circuited on the length check. No runtime behavior changes; rendered output is unchanged.

### Single validation layer
Moved the cross-field `fail`-based guards out of the resource templates into `templates/validations.yaml`:
- the HPA target-utilization guard (from `hpa.yaml`), and
- the PodDisruptionBudget `minAvailable`/`maxUnavailable` mutual-exclusion guard (from `pdb.yaml`).

`hpa.yaml`/`pdb.yaml` keep only the booleans they need to decide what to render. Added a header to `validations.yaml` documenting the split with `values.schema.json` (which owns structural/enum/pattern/conditional rules) and a matching `$comment` in the schema, so the two sources of truth are cross-referenced.

### Credential policy decoupled from Secret rendering (SRP)
Extracted the admin-password / master-key complexity and length policy out of `honua.secretData` into `honua.validateSecretComplexity`, invoked from the validation layer (gated on `secret.create`). `honua.secretData` now only resolves and renders the payload. Thresholds are defined once (`honua.minAdminPasswordLength` / `honua.minMasterKeyLength`). The preflight Job retains its own copy of the policy as the install-time enforcement point for externally-managed secrets the chart cannot see at render time.

### DRY
Factored the empty/nil env-stripping loop duplicated by `configmap.yaml` and `honua.secretData` into a shared `honua.nonEmptyEnv` helper.

### Test coverage
Replaced the single coarse admin-password test (which used an 11-char value and only exercised the length check) with a matrix of 16+ char fixtures, each violating exactly one complexity rule and asserting its specific message. Added a message assertion to the master-key test and added negative tests for the digest-format and `release.id` label guards, which previously had none.

## Verification
- `helm lint` passes for base, dev, stage, prod.
- `helm template` renders cleanly for every `ci-values/*` overlay and dev/stage/prod; the base ConfigMap/Secret output is byte-identical to trunk.
- Each complexity guard fails render with its specific message; the moved HPA/PDB guards still fire; `secret.create=true` still renders a complete Secret.

## Closes
Closes #35

Remaining items are **S3** polish (out of the high/medium scope), left for a small follow-up: inlining the `honua.preflightRedisRequired` pass-through alias (deferred here to avoid touching `preflight-job.yaml`, which #43 also edits), unifying the defensive-access idiom across helpers, and fully extracting connection-string derivation into its own returnable helper (Helm `include` cannot return a dict, so derivation still lives in `honua.secretData`).
