### PR TITLE
ci(governance): guard against AI/agent attribution; version-agnostic AGENTS.md

### DIFF
--- a/.github/workflows/commit-policy.yml
+++ b/.github/workflows/commit-policy.yml
@@ -1,0 +1,27 @@
+name: Commit policy
+
+# Enforces the AGENTS.md authorship rule: commits must be authored as the repo
+# owner only, with no AI/agent attribution (no "Co-Authored-By: Claude/Codex/..."
+# trailers, no "Generated with ..." lines, no robot emoji). Prevents recurrence
+# of the attribution trailers flagged in the release audit.
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  no-ai-attribution:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          # Need the PR's base and head commits to scan the full PR range.
+          fetch-depth: 0
+
+      - name: Reject AI/agent attribution in commit messages
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: scripts/check-no-ai-attribution.sh --range "${BASE_SHA}..${HEAD_SHA}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,9 @@ pods stop before new pods start during a migrating upgrade.
 ## Tech Stack
 
 - **Helm** chart, `apiVersion: v2`, `type: application` (see `honua/Chart.yaml`).
-- Chart `version: 0.2.0`, `appVersion: "0.0.0"` (placeholder; stamped at release).
+- Chart `version` and `appVersion` are defined in `honua/Chart.yaml`, which is the
+  single source of truth; `appVersion` is a `"0.0.0"` placeholder stamped at
+  release. Do not restate the concrete version here or elsewhere in docs.
 - Subchart dependencies (Bitnami, from `https://charts.bitnami.com/bitnami`):
   - `postgresql` `>=12.0.0 <16.0.0` (gated by `postgresql.enabled`, dev only —
     Bitnami PostgreSQL does NOT include PostGIS, which Honua requires).
@@ -168,3 +170,12 @@ This machine runs many agents concurrently (**Codex + Claude**, often via agentf
 2. **Commit and push when you finish a task** so your worktree can be reclaimed. An hourly job (`honua-clean`) removes a worktree ONLY when it is clean AND fully pushed (merged, remote-gone, or idle >=2d). Dirty or unpushed worktrees are NEVER touched — but uncommitted/unpushed work blocks reclamation and is at risk if the instance is reset. Build artifacts (bin/obj and untracked node_modules) are reclaimed automatically and safely.
 
 3. **Commit hygiene — no agent attribution.** Author every commit as the repo owner only (git identity: Mike McDougall <mike@honua.io>). Do **NOT** add any agent/tool attribution to commits: no `Co-Authored-By: Claude ...`, no `Co-Authored-By: Codex ...` (or other bot co-authors), and no "Generated with Claude Code" / "Generated with Codex" / "🤖" lines in the message or PR body. Write a plain, descriptive commit message and stop.
+
+   This is enforced in CI: `.github/workflows/commit-policy.yml` runs `scripts/check-no-ai-attribution.sh` over every pull request and fails if any commit message carries AI/agent attribution (Dependabot and GitHub Actions bot co-authors are allowed). To catch it before you push, wire the same check as a local `commit-msg` hook:
+
+   ```bash
+   ln -s ../../scripts/check-no-ai-attribution.sh .git/hooks/commit-msg
+   # or, if your git does not run the script directly:
+   printf '#!/bin/sh\nexec scripts/check-no-ai-attribution.sh --message-file "$1"\n' > .git/hooks/commit-msg
+   chmod +x .git/hooks/commit-msg
+   ```

--- a/scripts/check-no-ai-attribution.sh
+++ b/scripts/check-no-ai-attribution.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+#
+# Reject AI/agent attribution in commit messages.
+#
+# AGENTS.md requires every commit (and PR body) to be authored as the repo owner
+# only: no AI/agent co-author trailers (e.g. "Co-Authored-By: Claude ...",
+# "Co-Authored-By: Codex ..."), no "Generated with ..." attribution lines, and no
+# robot emoji. This script is the enforcement point invoked by CI
+# (.github/workflows/commit-policy.yml) and can also be wired as a local
+# commit-msg hook.
+#
+# Usage:
+#   scripts/check-no-ai-attribution.sh                      # scan origin/trunk..HEAD
+#   scripts/check-no-ai-attribution.sh --range <revrange>   # scan a commit range
+#   scripts/check-no-ai-attribution.sh --message-file <path># scan one message file
+#                                                           # (for a commit-msg hook)
+#
+# Dependabot and GitHub Actions bot co-authors are intentionally allowed; the
+# policy targets AI coding-assistant attribution, not accepted CI automation.
+set -euo pipefail
+
+# Co-Authored-By trailers naming an AI coding assistant or AI vendor.
+AI_COAUTHOR='[Cc]o-[Aa]uthored-[Bb]y:.*(Claude|Codex|Copilot|ChatGPT|GPT-|Anthropic|OpenAI|Cursor|Devin|Gemini|Sourcegraph|Tabnine|noreply@anthropic\.com)'
+# Any "[bot]" co-author other than the automation we explicitly accept.
+BOT_COAUTHOR='[Cc]o-[Aa]uthored-[Bb]y:.*\[bot\]'
+ALLOWED_BOTS='dependabot\[bot\]|github-actions\[bot\]'
+# "Generated with ..." attribution lines.
+GENERATED='[Gg]enerated with'
+# Robot emoji (U+1F916), expressed as bytes so this file stays ASCII.
+ROBOT=$'\xf0\x9f\xa4\x96'
+
+# Inspect a single commit message (passed on stdin). Echoes a reason and returns
+# 1 when forbidden attribution is found; returns 0 when clean.
+scan_message() {
+  local msg reason="" coauthors line
+  msg="$(cat)"
+
+  if printf '%s\n' "$msg" | grep -qE "$AI_COAUTHOR"; then
+    reason="AI co-author trailer"
+  elif printf '%s\n' "$msg" | grep -qE "$GENERATED"; then
+    reason='"Generated with" attribution line'
+  elif printf '%s\n' "$msg" | grep -qF "$ROBOT"; then
+    reason="robot emoji"
+  else
+    coauthors="$(printf '%s\n' "$msg" | grep -iE '^co-authored-by:' || true)"
+    while IFS= read -r line; do
+      [ -n "$line" ] || continue
+      if printf '%s' "$line" | grep -qE "$BOT_COAUTHOR" \
+        && ! printf '%s' "$line" | grep -qE "$ALLOWED_BOTS"; then
+        reason="disallowed bot co-author"
+        break
+      fi
+    done <<EOF
+$coauthors
+EOF
+  fi
+
+  if [ -n "$reason" ]; then
+    printf '%s' "$reason"
+    return 1
+  fi
+  return 0
+}
+
+mode="range"
+arg="origin/trunk..HEAD"
+case "${1:-}" in
+  --message-file)
+    mode="file"; arg="${2:?--message-file requires a path}" ;;
+  --range)
+    mode="range"; arg="${2:?--range requires a rev-range}" ;;
+  "" )
+    : ;;
+  -h|--help)
+    grep '^#' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+  * )
+    echo "unknown argument: $1" >&2; exit 2 ;;
+esac
+
+status=0
+
+if [ "$mode" = "file" ]; then
+  if reason="$(scan_message <"$arg")"; then
+    echo "Commit message is free of AI/agent attribution."
+  else
+    echo "error: commit message contains forbidden attribution (${reason})." >&2
+    echo "AGENTS.md: author as the repo owner only, with no AI/agent attribution." >&2
+    status=1
+  fi
+  exit "$status"
+fi
+
+# Range mode: scan every commit in the range.
+commits="$(git rev-list "$arg")"
+if [ -z "$commits" ]; then
+  echo "No commits to check in range '${arg}'."
+  exit 0
+fi
+
+while IFS= read -r commit; do
+  [ -n "$commit" ] || continue
+  if reason="$(git show -s --format='%B' "$commit" | scan_message)"; then
+    continue
+  fi
+  echo "::error::commit ${commit} contains forbidden attribution (${reason})." >&2
+  git show -s --format='  %h %s' "$commit" >&2
+  status=1
+done <<EOF
+$commits
+EOF
+
+if [ "$status" -ne 0 ]; then
+  echo "" >&2
+  echo "Forbidden AI/agent attribution found (see above). AGENTS.md requires" >&2
+  echo "commits to be authored as the repo owner only, with no AI/agent" >&2
+  echo "co-authors, no \"Generated with ...\" lines, and no robot emoji." >&2
+  exit 1
+fi
+
+echo "Commit messages in '${arg}' are free of AI/agent attribution."


### PR DESCRIPTION
## Summary

Repo-governance hardening from the release audit. Delivers the in-repo-actionable portion of #38: the recurrence guard the audit explicitly asked for, plus the stale onboarding-doc fix.

### Recurrence guard against AI/agent attribution
Adds `scripts/check-no-ai-attribution.sh` and a `Commit policy` workflow (`.github/workflows/commit-policy.yml`) that scans every pull request's commit messages and fails on AI/agent attribution: AI co-author trailers (Claude/Codex/Copilot/...), tool-generated attribution lines, the robot emoji, and any non-allowlisted `[bot]` co-author. Dependabot and GitHub Actions bot co-authors are intentionally allowed so accepted CI automation is not blocked. The script doubles as a local `commit-msg` hook (`--message-file`); AGENTS.md documents how to wire it. This is the "add a guard to prevent attribution recurrence" deliverable from the audit.

### Stale onboarding doc
AGENTS.md stated the chart version as `0.2.0` while `Chart.yaml` is `0.4.0`. Made the doc version-agnostic by pointing at `honua/Chart.yaml` as the single source of truth rather than restating a concrete version that drifts. The `Chart.lock` pin claims (postgresql `15.5.38`, redis `20.13.4`) were re-verified and remain accurate.

## Verification
- `commit-policy.yml` is valid YAML; the script is committed mode `100755` with LF endings (matching `scripts/aks-smoke.sh`).
- The guard was exercised across 8 cases: it flags the audited commit `a84cd7e`, the `Claude` co-author trailer, tool-generated lines, and the robot emoji; it passes clean messages and allows `dependabot[bot]`; it rejects a non-allowlisted `[bot]` co-author. It passes on this PR's own commits.

## Refs
Refs #38

This PR does **not** fully close #38 — two sub-items are genuinely gated and need a maintainer decision (see the issue and the "flagged" report):
- **History scrub (S2):** removing the `Co-Authored-By: Claude` trailer already baked into published history (`a84cd7e`) requires rewriting shared history / a force-push, which the repo rules forbid.
- **License (S3):** confirming Apache-2.0 is deliberate vs switching to Elastic License 2.0 (with headers) is a licensing decision, not a code change.
