### PR TITLE
ci: scan direct-to-trunk pushes for AI/agent attribution

### DIFF
--- a/.github/workflows/commit-policy.yml
+++ b/.github/workflows/commit-policy.yml
@@ -4,9 +4,17 @@ name: Commit policy
 # owner only, with no AI/agent attribution (no "Co-Authored-By: Claude/Codex/..."
 # trailers, no "Generated with ..." lines, no robot emoji). Prevents recurrence
 # of the attribution trailers flagged in the release audit.
+#
+# Runs on both pull_request and push to trunk. The pull_request trigger scans
+# the PR range; the push trigger closes the gap where a commit landed directly
+# on trunk (or via an admin/force merge) would never be scanned by a PR-only
+# gate.
 
 on:
   pull_request:
+  push:
+    branches:
+      - trunk
 
 permissions:
   contents: read
@@ -17,11 +25,29 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
-          # Need the PR's base and head commits to scan the full PR range.
+          # Need the base and head commits to scan the full range.
           fetch-depth: 0
 
-      - name: Reject AI/agent attribution in commit messages
+      - name: Reject AI/agent attribution in commit messages (pull_request)
+        if: github.event_name == 'pull_request'
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: scripts/check-no-ai-attribution.sh --range "${BASE_SHA}..${HEAD_SHA}"
+
+      - name: Reject AI/agent attribution in commit messages (push)
+        if: github.event_name == 'push'
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+          AFTER_SHA: ${{ github.event.after }}
+        run: |
+          set -euo pipefail
+          zero='0000000000000000000000000000000000000000'
+          # On a brand-new branch (or when the before commit is unknown/missing
+          # locally) there is no usable base, so scan every commit reachable from
+          # the pushed head. Otherwise scan only the newly pushed range.
+          if [ "${BEFORE_SHA}" = "${zero}" ] || ! git cat-file -e "${BEFORE_SHA}^{commit}" 2>/dev/null; then
+            scripts/check-no-ai-attribution.sh --range "${AFTER_SHA}"
+          else
+            scripts/check-no-ai-attribution.sh --range "${BEFORE_SHA}..${AFTER_SHA}"
+          fi


### PR DESCRIPTION
## Summary

Closes the enforcement gap flagged in the release audit (round 4) for the no-AI-attribution policy.

**Finding** (`.github/workflows/commit-policy.yml`, S2 / LICENSING): `commit-policy.yml` ran only `on: pull_request` and scanned `base.sha..head.sha`. A commit that lands directly on `trunk` (or is merged via an admin/force path that bypasses the PR gate) was therefore **never scanned**, so the AGENTS.md no-attribution rule could be bypassed. The audit traced one such historical commit (`a84cd7e`, "docs: fix helm chart paths for standalone repo") that carries a `Co-Authored-By: Claude ... <noreply@anthropic.com>` trailer and predates the PR-only gate.

## Change

Add a `push` trigger on `trunk` to the existing workflow. It reuses the same `scripts/check-no-ai-attribution.sh` enforcement point and scans the newly pushed range:

- Normal push: `github.event.before..github.event.after`.
- New branch / unavailable before-SHA (zero SHA): falls back to scanning the full history reachable from the pushed head (`--range <after>`).

The `pull_request` behavior is unchanged; the two paths are gated by `github.event_name`.

## Verification

- `python3 yaml.safe_load` parses the workflow; the embedded `run` block passes `bash -n`.
- `scripts/check-no-ai-attribution.sh --range a84cd7e` and `--range a84cd7e~1..a84cd7e` both **fail** (exit non-zero) on the known bad commit; a clean range (`origin/trunk~1..origin/trunk`) and this PR's own commit both **pass**.

## Not included (out of scope for a non-destructive PR)

Scrubbing the existing attribution trailer from commit `a84cd7e` in history requires a filter-repo/rebase rewrite and a force-push to `trunk`, which is a destructive history rewrite and is intentionally left out of this PR. It should be done as a deliberate, coordinated pre-release step. This PR ensures that once history is clean, no future direct-to-trunk push can reintroduce attribution unnoticed.
