### PR TITLE
Add container lifecycle passthrough for zero-downtime preStop drain

### DIFF
--- a/docs/values-contract.md
+++ b/docs/values-contract.md
@@ -75,7 +75,7 @@ from rendered ConfigMap and Secret data before template-required checks run.
 | --- | --- | --- |
 | Image | `image.repository`, `image.tag`, `image.digest`, `image.pullPolicy`, `image.pullSecrets` | Production release lanes should prefer `image.digest` with `image.tag=""`; immutable tags are the fallback. |
 | Release evidence | `release.id`, `release.manifest`, `release.digest`, `release.appVersion` | `release.id` and the effective app version must be label-safe; use `release.manifest` for free-form build metadata and `release.digest` for SHA-256 evidence. |
-| Upgrade contract | `strategy.*`, `terminationGracePeriodSeconds`, `preflight.*` | Default `Recreate` is migration-safe for inline migrations; preflight validates required keys, database and Redis reachability, and optional registry reachability. |
+| Upgrade contract | `strategy.*`, `terminationGracePeriodSeconds`, `lifecycle`, `preflight.*` | Default `Recreate` is migration-safe for inline migrations; preflight validates required keys, database and Redis reachability, and optional registry reachability. For `RollingUpdate`/HPA scale-down set a `lifecycle.preStop` sleep so Service endpoint removal propagates before SIGTERM (zero-downtime drain). |
 | Naming | `nameOverride`, `fullnameOverride` | Use only for DNS length constraints or platform naming standards. |
 | ServiceAccount | `serviceAccount.*` | Token automount stays disabled by default. |
 | Routing | `service.*`, `ingress.*` | Ingress class, DNS, TLS, and annotations are platform-specific. |

--- a/honua/README.md
+++ b/honua/README.md
@@ -393,6 +393,7 @@ characters. For non-development deployments, it also fails if
 | `preflight.retryDelaySeconds` | 3 | Delay between preflight reachability probe attempts. |
 | `preflight.registryCheck.enabled` | true | Check the target image registry `/v2/` endpoint before apply. |
 | `terminationGracePeriodSeconds` | 60 | Pod shutdown grace period for lock release and clean termination. |
+| `lifecycle` | `{}` | Container lifecycle hooks passed through verbatim. For zero-downtime `RollingUpdate` / HPA scale-down, set a `preStop` sleep (e.g. `preStop.exec.command: ["/bin/sh","-c","sleep 5"]`) so Service endpoint removal propagates to kube-proxy/ingress before SIGTERM; keep it shorter than `terminationGracePeriodSeconds`. Left empty under the default `Recreate` strategy, where a preStop delay only slows termination. |
 | `tmpVolume.enabled` | true | Mount a writable `/tmp` emptyDir. Required because `readOnlyRootFilesystem` is true and the server writes temp files; disable only if the image never writes to disk. |
 | `tmpVolume.sizeLimit` | `""` | Optional `emptyDir` size cap for `/tmp` (e.g. `1Gi`). |
 | `affinity` | `{}` | Pod affinity rules. When empty, the chart applies a soft pod anti-affinity spreading replicas across nodes for multi-replica workloads (`autoscaling.enabled` or `replicaCount > 1`). |

--- a/honua/ci-values/rolling-update.yaml
+++ b/honua/ci-values/rolling-update.yaml
@@ -12,6 +12,13 @@ strategy:
   rollingUpdate:
     maxSurge: 0
     maxUnavailable: 1
+# preStop drain so Service endpoint removal propagates to kube-proxy/ingress
+# before SIGTERM, avoiding connection resets during the RollingUpdate window.
+# Kept shorter than terminationGracePeriodSeconds (60).
+lifecycle:
+  preStop:
+    exec:
+      command: ["/bin/sh", "-c", "sleep 5"]
 release:
   id: honua-ci-rolling
   manifest: "ci://honua-helm/rolling-update"

--- a/honua/templates/deployment.yaml
+++ b/honua/templates/deployment.yaml
@@ -98,6 +98,10 @@ spec:
             {{- toYaml .Values.readinessProbe | nindent 12 }}
           startupProbe:
             {{- toYaml .Values.startupProbe | nindent 12 }}
+          {{- with .Values.lifecycle }}
+          lifecycle:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           {{- if or .Values.tmpVolume.enabled .Values.extraVolumeMounts }}

--- a/honua/values.schema.json
+++ b/honua/values.schema.json
@@ -85,6 +85,10 @@
       "type": "integer",
       "minimum": 0
     },
+    "lifecycle": {
+      "type": "object",
+      "description": "Container lifecycle hooks for the honua container (e.g. a preStop sleep to drain Service endpoints during RollingUpdate / HPA scale-down)."
+    },
     "preflight": {
       "type": "object",
       "properties": {

--- a/honua/values.yaml
+++ b/honua/values.yaml
@@ -128,6 +128,32 @@ strategy:
 
 terminationGracePeriodSeconds: 60
 
+# Container lifecycle hooks (passed through verbatim to the honua container).
+#
+# Zero-downtime rollouts (strategy.type: RollingUpdate, and HPA scale-down)
+# need a preStop delay. When a pod is terminated, Kubernetes sends SIGTERM and
+# removes the Service endpoint concurrently; endpoint removal is asynchronous
+# and takes time to propagate to kube-proxy and ingress controllers. Without a
+# preStop pause the server can start shutting down while kube-proxy still routes
+# new connections to it, so requests in the propagation window get
+# connection-refused/reset. terminationGracePeriodSeconds bounds the kill but
+# does NOT close this race.
+#
+# A preStop sleep holds the container running (the pod stays Terminating) so the
+# endpoint deletion has time to propagate before the process receives SIGTERM.
+# Keep the sleep shorter than terminationGracePeriodSeconds. Recommended for any
+# RollingUpdate / autoscaled (MultiNode) deployment:
+#
+# lifecycle:
+#   preStop:
+#     exec:
+#       command: ["/bin/sh", "-c", "sleep 5"]
+#
+# Left empty by default because the chart's default strategy is Recreate
+# (old pods stop before new pods start), where a preStop delay only slows
+# termination without benefit.
+lifecycle: {}
+
 # Writable scratch volume. securityContext.readOnlyRootFilesystem is true, so the
 # container filesystem is read-only except for mounts. .NET and geospatial code
 # paths write to /tmp (temp files, shadow copies, GDAL scratch), which would hit


### PR DESCRIPTION
## Problem

Finding (round5 release audit, S2 — reliability/graceful-degradation), `honua/templates/deployment.yaml:79`:

The honua container defines no `lifecycle.preStop` hook and `values.yaml` exposed no lifecycle passthrough, so operators cannot add a graceful-drain delay without forking the template.

On the HA path the chart advertises (autoscaling + MultiNode + RollingUpdate, and HPA scale-down), Kubernetes sends SIGTERM and removes the Service endpoint **concurrently**. Endpoint removal is asynchronous and propagates to kube-proxy / ingress after a delay. Without a preStop pause, the server can begin shutting down while kube-proxy still routes new connections to it, so in-flight and newly-routed requests in the propagation window get connection-refused/reset. `terminationGracePeriodSeconds: 60` only bounds the kill; it does not close the endpoint-removal race. This is the classic zero-downtime-rollout gap, and it bites exactly the HA path the chart targets.

## Fix (per recommendation)

- **deployment.yaml**: add an optional `lifecycle` passthrough on the honua container, placed after the probes.
- **values.yaml**: add `lifecycle: {}` with documented preStop guidance. Left empty by default because the chart default `strategy.type` is `Recreate` (old pods stop before new pods start), where a preStop delay only slows termination without benefit. A blanket default sleep would regress the default/SingleInstance path, so the recommended preStop is documented and ready to enable for RollingUpdate / autoscaled deployments. Docs note keeping the sleep shorter than `terminationGracePeriodSeconds`.
- **values.schema.json**: register `lifecycle` (object) so it is documented/validated.
- **ci-values/rolling-update.yaml**: enable a `preStop` sleep so CI renders the new knob on the exact path it is designed for.
- **docs**: README values reference + values-contract upgrade-contract row document the knob and its terminationGracePeriodSeconds interaction.

## Verification

- `helm dependency build honua` (from committed Chart.lock)
- `helm lint honua -f honua/ci-values/base.yaml` — pass
- `helm lint honua -f honua/ci-values/rolling-update.yaml` — pass (schema validation included)
- `helm template ... -f base.yaml` — no `lifecycle` block rendered (default empty; behavior unchanged)
- `helm template ... -f rolling-update.yaml` — `lifecycle.preStop` rendered with correct indentation
