### PR TITLE
feat(chart): add SLO alerting rules and Alertmanager receiver surface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,11 +78,41 @@ jobs:
           set -euo pipefail
           grep -q 'kind: ServiceMonitor' /tmp/honua-rendered-observability.yaml
           grep -q 'kind: PrometheusRule' /tmp/honua-rendered-observability.yaml
+          grep -q 'kind: AlertmanagerConfig' /tmp/honua-rendered-observability.yaml
           grep -q 'OTEL_EXPORTER_OTLP_ENDPOINT' /tmp/honua-rendered-observability.yaml
           grep -q 'prometheus.io/scrape: "true"' /tmp/honua-rendered-observability.yaml
+          # Application SLO rules, including the GeoServices in-band 200-with-{error}
+          # signal that is invisible to load-balancer 5xx metrics, must render.
+          grep -q 'name: honua.slo' /tmp/honua-rendered-observability.yaml
+          grep -q 'alert: HonuaGeoServicesInBandErrorRateHigh' /tmp/honua-rendered-observability.yaml
+          grep -q 'alert: HonuaErrorBudgetFastBurn' /tmp/honua-rendered-observability.yaml
+          grep -q 'in_band="true"' /tmp/honua-rendered-observability.yaml
           # Metrics resources must NOT render in the baseline (opt-in only).
           if grep -q 'kind: ServiceMonitor' /tmp/honua-rendered-base.yaml; then
             echo "ServiceMonitor must not render without metrics.serviceMonitor.enabled."
+            exit 1
+          fi
+          if grep -q 'kind: PrometheusRule' /tmp/honua-rendered-base.yaml; then
+            echo "PrometheusRule must not render without metrics.prometheusRule.enabled."
+            exit 1
+          fi
+          if grep -q 'kind: AlertmanagerConfig' /tmp/honua-rendered-base.yaml; then
+            echo "AlertmanagerConfig must not render without metrics.alertmanagerConfig.enabled."
+            exit 1
+          fi
+
+      - name: Validate alertmanagerConfig guard fails without receivers
+        run: |
+          set +e
+          helm template honua ./honua \
+            -f honua/ci-values/base.yaml \
+            --set metrics.alertmanagerConfig.enabled=true \
+            > /tmp/honua-rendered-alertmanager-invalid.yaml 2>&1
+          status=$?
+          set -e
+          if [[ "${status}" -eq 0 ]]; then
+            echo "Expected alertmanagerConfig without receivers to fail."
+            cat /tmp/honua-rendered-alertmanager-invalid.yaml
             exit 1
           fi
 

--- a/honua/README.md
+++ b/honua/README.md
@@ -450,8 +450,8 @@ variables so the server's OpenTelemetry SDK exports to the collector.
 
 ### Prometheus (scrape)
 
-For a Prometheus Operator cluster, enable a `ServiceMonitor` and the baseline
-`PrometheusRule` availability alerts:
+For a Prometheus Operator cluster, enable a `ServiceMonitor` and the
+`PrometheusRule`:
 
 ```yaml
 metrics:
@@ -474,11 +474,52 @@ Service.
 
 The `ServiceMonitor`/`PrometheusRule` resources require the Prometheus Operator
 CRDs and a server build that exposes a Prometheus endpoint at the configured
-port/path. The shipped `PrometheusRule` alerts on availability
-(`kube_deployment_status_replicas_available == 0`) and crash-looping via
-kube-state-metrics, so it does not depend on any application metric being
-emitted. Application-level alerts (for example a GeoServices in-band error-rate
-alert) are added once the server exposes the corresponding metric.
+port/path.
+
+### Alerting (SLO rules + receivers)
+
+The `PrometheusRule` has two rule groups when `metrics.prometheusRule.enabled`:
+
+- **`honua.availability`** — infrastructure alerts on kube-state-metrics
+  (`kube_deployment_status_replicas_available == 0`, crash-looping). No
+  application metric required.
+- **`honua.slo`** (`metrics.prometheusRule.slo.enabled`, default true) —
+  request-availability, combined error-rate, and multi-window burn-rate alerts
+  built on the server's `honua_request_error_total` / `honua_http_requests_total`
+  counters. These deliberately **include the GeoServices in-band 200-with-`{error}`
+  signal**: GeoServices returns HTTP 200 with an `{error}` body for Esri-client
+  compatibility, so those failures are invisible to load-balancer 5xx metrics. The
+  server increments `honua_request_error_total` with `in_band="true"` for them, so
+  every ratio counts that class and `HonuaGeoServicesInBandErrorRateHigh` alerts on
+  it directly. Thresholds/windows mirror the honua-devops SLO rules and are fully
+  overridable under `metrics.prometheusRule.slo`. Scope the counters to this
+  release with `metrics.prometheusRule.slo.metricSelector`.
+
+Wire delivery with the `AlertmanagerConfig` receiver surface (does **not** deploy
+Alertmanager; the Alertmanager Operator merges it by namespace/label selector).
+Each SLO alert carries `severity` and `route` labels a route can match on:
+
+```yaml
+metrics:
+  alertmanagerConfig:
+    enabled: true
+    labels:
+      alertmanagerConfig: honua   # match your Alertmanager alertmanagerConfigSelector
+    route:
+      receiver: honua-slack
+      groupBy: ["alertname", "route"]
+      routes:
+        - matchers: [{ name: route, value: pagerduty-critical }]
+          receiver: honua-pagerduty
+    receivers:
+      - name: honua-slack
+        slackConfigs:
+          - apiURL: { name: honua-alertmanager-secrets, key: slackApiUrl }
+            channel: "#honua-alerts"
+      - name: honua-pagerduty
+        pagerdutyConfigs:
+          - routingKey: { name: honua-alertmanager-secrets, key: pagerdutyRoutingKey }
+```
 
 | Value | Default | Description |
 |-------|---------|-------------|
@@ -486,7 +527,10 @@ alert) are added once the server exposes the corresponding metric.
 | `observability.otlpProtocol` | `grpc` | OTLP protocol (`grpc` or `http/protobuf`). |
 | `metrics.serviceMonitor.enabled` | false | Render a Prometheus Operator `ServiceMonitor`. |
 | `metrics.serviceAnnotations.enabled` | false | Stamp `prometheus.io/*` scrape annotations on the Service. |
-| `metrics.prometheusRule.enabled` | false | Render the baseline availability `PrometheusRule`. |
+| `metrics.prometheusRule.enabled` | false | Render the `PrometheusRule` (infra + SLO alerts). |
+| `metrics.prometheusRule.slo.enabled` | true | Emit the `honua.slo` group (availability / error-rate / burn-rate / in-band). Applies only when `prometheusRule.enabled`. |
+| `metrics.prometheusRule.slo.metricSelector` | `""` | Label matcher scoping the counters to this deployment, e.g. `service="honua-server"`. |
+| `metrics.alertmanagerConfig.enabled` | false | Render an `AlertmanagerConfig` (receivers + route). Requires at least one receiver. |
 
 ## Geospatial HPA tuning guidance
 

--- a/honua/ci-values/observability.yaml
+++ b/honua/ci-values/observability.yaml
@@ -1,5 +1,7 @@
 # Exercises the observability/metrics integration: OTLP endpoint wiring plus the
-# ServiceMonitor, Prometheus scrape annotations, and PrometheusRule resources.
+# ServiceMonitor, Prometheus scrape annotations, the PrometheusRule (baseline
+# availability + application SLO rules, including the GeoServices in-band
+# 200-with-{error} signal), and the AlertmanagerConfig receiver surface.
 config:
   env:
     HONUA_OBSERVABILITY: "true"
@@ -21,6 +23,37 @@ metrics:
     enabled: true
     labels:
       release: kube-prometheus-stack
+    slo:
+      enabled: true
+      metricSelector: 'service="honua-server"'
+      alertLabels:
+        service: honua-server
+  alertmanagerConfig:
+    enabled: true
+    labels:
+      alertmanagerConfig: honua
+    route:
+      receiver: honua-slack
+      groupBy: ["alertname", "route"]
+      routes:
+        - matchers:
+            - name: route
+              value: pagerduty-critical
+          receiver: honua-pagerduty
+    receivers:
+      - name: honua-slack
+        slackConfigs:
+          - apiURL:
+              name: honua-alertmanager-secrets
+              key: slackApiUrl
+            channel: "#honua-alerts"
+            sendResolved: true
+      - name: honua-pagerduty
+        pagerdutyConfigs:
+          - routingKey:
+              name: honua-alertmanager-secrets
+              key: pagerdutyRoutingKey
+            sendResolved: true
 
 secret:
   env:

--- a/honua/templates/alertmanagerconfig.yaml
+++ b/honua/templates/alertmanagerconfig.yaml
@@ -1,0 +1,27 @@
+{{- $amConfig := get (.Values.metrics | default dict) "alertmanagerConfig" | default dict }}
+{{- if get $amConfig "enabled" }}
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: AlertmanagerConfig
+metadata:
+  name: {{ include "honua.fullname" . }}
+  labels:
+    {{- include "honua.labels" . | nindent 4 }}
+    {{- with (get $amConfig "labels") }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with (get $amConfig "annotations") }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with (get $amConfig "route") }}
+  route:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  receivers:
+    {{- toYaml (get $amConfig "receivers") | nindent 4 }}
+  {{- with (get $amConfig "inhibitRules") }}
+  inhibitRules:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/honua/templates/prometheusrule.yaml
+++ b/honua/templates/prometheusrule.yaml
@@ -1,4 +1,12 @@
 {{- if .Values.metrics.prometheusRule.enabled }}
+{{- $slo := .Values.metrics.prometheusRule.slo | default dict }}
+{{- $sel := trim (default "" (get $slo "metricSelector")) }}
+{{- $inbandSel := ternary (printf "%s,in_band=\"true\"" $sel) "in_band=\"true\"" (ne $sel "") }}
+{{- $budget := $slo.errorBudget | default 0.010 }}
+{{- $runbook := $slo.runbookUrl | default "" }}
+{{- $alertLabels := $slo.alertLabels | default dict }}
+{{- /* Combined error ratio over a window: transport 5xx AND in-band 200-with-{error}. */ -}}
+{{- $errRatio := printf "sum(rate(honua_request_error_total{%s}[%%s])) / clamp_min(sum(rate(honua_http_requests_total{%s}[%%s])), 0.001)" $sel $sel }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
@@ -28,4 +36,99 @@ spec:
           annotations:
             summary: "Honua container is restarting frequently"
             description: 'A Honua container in namespace {{ .Release.Namespace }} has restarted more than 3 times in 15 minutes.'
+{{- if $slo.enabled }}
+    - name: honua.slo
+      rules:
+{{- with $slo.availability }}
+{{- if .enabled }}
+        - alert: HonuaAvailabilitySloViolation
+          expr: '(1 - ({{ printf "sum(rate(honua_request_error_total{%s}[%s]))" $sel .window }} / clamp_min({{ printf "sum(rate(honua_http_requests_total{%s}[%s]))" $sel .window }}, 0.001))) < {{ .target }}'
+          for: {{ .for }}
+          labels:
+            severity: {{ .severity | quote }}
+            {{- with .route }}
+            route: {{ . | quote }}
+            {{- end }}
+            {{- with $alertLabels }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          annotations:
+            summary: "Honua request-availability SLO violation"
+            description: 'Rolling {{ .window }} request availability (including GeoServices 200-with-{error} envelopes) is below the {{ .target }} target.'
+            {{- with $runbook }}
+            runbook_url: {{ . | quote }}
+            {{- end }}
+{{- end }}
+{{- end }}
+{{- with $slo.errorRate }}
+{{- if .enabled }}
+        - alert: HonuaErrorRateHigh
+          expr: '({{ printf $errRatio .window .window }}) > {{ .threshold }}'
+          for: {{ .for }}
+          labels:
+            severity: {{ .severity | quote }}
+            {{- with .route }}
+            route: {{ . | quote }}
+            {{- end }}
+            {{- with $alertLabels }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          annotations:
+            summary: "Honua error rate above threshold"
+            description: 'Combined error rate over {{ .window }} (transport 5xx plus GeoServices in-band 200-with-{error} envelopes) is above {{ .threshold }}.'
+            {{- with $runbook }}
+            runbook_url: {{ . | quote }}
+            {{- end }}
+{{- end }}
+{{- end }}
+{{- with $slo.inBandErrors }}
+{{- if .enabled }}
+        - alert: HonuaGeoServicesInBandErrorRateHigh
+          expr: '(sum(rate(honua_request_error_total{ {{- $inbandSel -}} }[{{ .window }}])) / clamp_min({{ printf "sum(rate(honua_http_requests_total{%s}[%s]))" $sel .window }}, 0.001)) > {{ .threshold }}'
+          for: {{ .for }}
+          labels:
+            severity: {{ .severity | quote }}
+            {{- with .route }}
+            route: {{ . | quote }}
+            {{- end }}
+            {{- with $alertLabels }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          annotations:
+            summary: "Honua GeoServices in-band (HTTP 200) error rate high"
+            description: 'GeoServices returns HTTP 200 with an {error} body for Esri compatibility, so these failures are invisible to load-balancer 5xx metrics. The in-band error rate over {{ .window }} is above {{ .threshold }}.'
+            {{- with $runbook }}
+            runbook_url: {{ . | quote }}
+            {{- end }}
+{{- end }}
+{{- end }}
+{{- with $slo.burnRate }}
+{{- if .enabled }}
+{{- range $tier, $cfg := (dict "Fast" .fast "Medium" .medium "Slow" .slow) }}
+{{- if $cfg }}
+        - alert: HonuaErrorBudget{{ $tier }}Burn
+          expr: '(({{ printf $errRatio $cfg.window $cfg.window }}) / {{ $budget }}) > {{ $cfg.threshold }}'
+          for: {{ $cfg.for }}
+          labels:
+            severity: {{ $cfg.severity | quote }}
+            {{- with $cfg.route }}
+            route: {{ . | quote }}
+            {{- end }}
+            {{- with $alertLabels }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          annotations:
+            summary: "Honua error-budget {{ lower $tier }} burn"
+            description: 'Error-budget burn over {{ $cfg.window }} (including GeoServices in-band 200-with-{error} envelopes) exceeds {{ $cfg.threshold }}x. Hold promotion and evaluate rollback.'
+            {{- with $runbook }}
+            runbook_url: {{ . | quote }}
+            {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- with $slo.extraRules }}
+        {{- toYaml . | nindent 8 }}
+{{- end }}
+{{- end }}
 {{- end }}

--- a/honua/templates/validations.yaml
+++ b/honua/templates/validations.yaml
@@ -118,6 +118,17 @@
 {{- end -}}
 {{- end -}}
 
+{{- /* An AlertmanagerConfig with no receivers is a no-op that silently drops
+       alerts. When the receiver surface is enabled, require at least one
+       receiver so the chart cannot ship "routing on, nowhere to deliver". */ -}}
+{{- $metricsValues := .Values.metrics | default dict -}}
+{{- $amConfig := get $metricsValues "alertmanagerConfig" | default dict -}}
+{{- if eq (toString (default false (get $amConfig "enabled"))) "true" -}}
+{{- if not (get $amConfig "receivers") -}}
+{{- fail "metrics.alertmanagerConfig.enabled is true but metrics.alertmanagerConfig.receivers is empty. Define at least one receiver (name + a *Configs list), or disable metrics.alertmanagerConfig so alerts are not routed into a no-op." -}}
+{{- end -}}
+{{- end -}}
+
 {{- /* Autoscaling requires at least one positive target utilization. Moved here
        from hpa.yaml so the cross-field guard lives in the validation layer; the
        schema also requires this for autoscaling.enabled=true. */ -}}

--- a/honua/values.schema.json
+++ b/honua/values.schema.json
@@ -3,6 +3,18 @@
   "type": "object",
   "description": "Values contract for the Honua Server Helm chart.",
   "$comment": "This schema owns structural validation: types, enums, patterns, min/max, and the conditional rules in allOf (image tag XOR digest, digest pattern, pullPolicy-with-digest, RollingUpdate non-zero budget, autoscaling target presence, secret/redis/postgresql requirements). Cross-field render-time guards and operator-friendly failure messages live in templates/validations.yaml. Where a rule appears in both places it is enforced structurally here and explained there; keep the two aligned.",
+  "definitions": {
+    "honuaBurnRateTier": {
+      "type": "object",
+      "properties": {
+        "threshold": { "type": "number", "minimum": 0 },
+        "window": { "type": "string" },
+        "for": { "type": "string" },
+        "severity": { "type": "string" },
+        "route": { "type": "string" }
+      }
+    }
+  },
   "properties": {
     "replicaCount": {
       "type": "integer",
@@ -345,7 +357,73 @@
           "type": "object",
           "properties": {
             "enabled": { "type": "boolean" },
-            "labels": { "type": "object" }
+            "labels": { "type": "object" },
+            "slo": {
+              "type": "object",
+              "description": "Application SLO alert rules (availability, error-rate, burn-rate, GeoServices in-band 200-with-error).",
+              "properties": {
+                "enabled": { "type": "boolean" },
+                "metricSelector": { "type": "string" },
+                "alertLabels": { "type": "object" },
+                "runbookUrl": { "type": "string" },
+                "errorBudget": { "type": "number", "exclusiveMinimum": 0, "maximum": 1 },
+                "availability": {
+                  "type": "object",
+                  "properties": {
+                    "enabled": { "type": "boolean" },
+                    "target": { "type": "number", "exclusiveMinimum": 0, "maximum": 1 },
+                    "window": { "type": "string" },
+                    "for": { "type": "string" },
+                    "severity": { "type": "string" },
+                    "route": { "type": "string" }
+                  }
+                },
+                "errorRate": {
+                  "type": "object",
+                  "properties": {
+                    "enabled": { "type": "boolean" },
+                    "threshold": { "type": "number", "minimum": 0 },
+                    "window": { "type": "string" },
+                    "for": { "type": "string" },
+                    "severity": { "type": "string" },
+                    "route": { "type": "string" }
+                  }
+                },
+                "inBandErrors": {
+                  "type": "object",
+                  "properties": {
+                    "enabled": { "type": "boolean" },
+                    "threshold": { "type": "number", "minimum": 0 },
+                    "window": { "type": "string" },
+                    "for": { "type": "string" },
+                    "severity": { "type": "string" },
+                    "route": { "type": "string" }
+                  }
+                },
+                "burnRate": {
+                  "type": "object",
+                  "properties": {
+                    "enabled": { "type": "boolean" },
+                    "fast": { "$ref": "#/definitions/honuaBurnRateTier" },
+                    "medium": { "$ref": "#/definitions/honuaBurnRateTier" },
+                    "slow": { "$ref": "#/definitions/honuaBurnRateTier" }
+                  }
+                },
+                "extraRules": { "type": "array" }
+              }
+            }
+          }
+        },
+        "alertmanagerConfig": {
+          "type": "object",
+          "description": "AlertmanagerConfig receiver/route surface (monitoring.coreos.com/v1alpha1).",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "labels": { "type": "object" },
+            "annotations": { "type": "object" },
+            "route": { "type": "object" },
+            "receivers": { "type": "array" },
+            "inhibitRules": { "type": "array" }
           }
         }
       }

--- a/honua/values.yaml
+++ b/honua/values.yaml
@@ -299,11 +299,97 @@ metrics:
     enabled: false
     path: /metrics
   # PrometheusRule with baseline availability alerts (zero available replicas,
-  # crash-looping). These alert on kube-state-metrics series, so they do not
-  # depend on any application metric being emitted yet.
+  # crash-looping) plus opt-in application SLO alerts. The baseline alerts read
+  # kube-state-metrics series, so they do not depend on any application metric.
   prometheusRule:
     enabled: false
     labels: {}
+    # Application SLO alerts built on Honua's request/error counters. These add the
+    # request-availability, error-rate, and multi-window burn-rate signals — and
+    # critically the GeoServices in-band 200-with-{error} signal. Those error
+    # envelopes are returned with HTTP 200 for Esri-client compatibility, so they
+    # are invisible to load-balancer / transport 5xx metrics. The server increments
+    # honua_request_error_total with in_band="true" for them, so every ratio below
+    # (which sums the whole honua_request_error_total counter) catches that class,
+    # and inBandErrors alerts on it directly. Mirrors the honua-devops SLO rules.
+    slo:
+      enabled: true
+      # Optional label matcher fragment scoping the counters to this deployment,
+      # e.g. 'service="honua-server"' or 'namespace="honua"'. Empty = all Honua
+      # series scraped by the Prometheus that loads this rule.
+      metricSelector: ""
+      # Extra labels merged onto every SLO alert (identity + Alertmanager routing).
+      alertLabels:
+        service: honua-server
+      runbookUrl: "https://github.com/honua-io/honua-devops/blob/main/docs/slo-release-gates.md"
+      # Error budget: the fraction of requests allowed to error. It is the burn-rate
+      # denominator (burn rate = observed error ratio / errorBudget).
+      errorBudget: 0.010
+      # Rolling request-availability alert (1 - error ratio) < target.
+      availability:
+        enabled: true
+        target: 0.990
+        window: 30d
+        for: 10m
+        severity: critical
+        route: pagerduty-critical
+      # Short-window combined (transport 5xx + in-band 200-with-{error}) error rate.
+      errorRate:
+        enabled: true
+        threshold: 0.010
+        window: 5m
+        for: 10m
+        severity: warning
+        route: slack-warning
+      # Dedicated GeoServices 200-with-{error} in-band signal so the LB-invisible
+      # error class is never masked by a healthy transport (5xx) picture.
+      inBandErrors:
+        enabled: true
+        threshold: 0.010
+        window: 5m
+        for: 10m
+        severity: warning
+        route: slack-warning
+      # Multi-window error-budget burn-rate alerts (fast/medium/slow).
+      burnRate:
+        enabled: true
+        fast:
+          threshold: 14.4
+          window: 5m
+          for: 5m
+          severity: critical
+          route: pagerduty-critical
+        medium:
+          threshold: 6.0
+          window: 30m
+          for: 15m
+          severity: warning
+          route: slack-warning
+        slow:
+          threshold: 3.0
+          window: 6h
+          for: 30m
+          severity: warning
+          route: email-info
+      # Operator-supplied rules appended verbatim to the honua.slo group.
+      extraRules: []
+  # AlertmanagerConfig receiver/route surface (monitoring.coreos.com/v1alpha1).
+  # This wires WHERE the alerts above are delivered (PagerDuty/Slack/email/...);
+  # the Alertmanager Operator merges it by namespace/label selector. It does NOT
+  # deploy Alertmanager. Disabled by default; at least one receiver is required
+  # when enabled. The SLO alerts carry `severity` and `route` labels that a route
+  # can match on (e.g. route.matchers: [{name: route, value: pagerduty-critical}]).
+  alertmanagerConfig:
+    enabled: false
+    # Extra labels so the Alertmanager `alertmanagerConfigSelector` can adopt this.
+    labels: {}
+    annotations: {}
+    # Pass-through AlertmanagerConfig spec.route (matchers, groupBy, receiver, ...).
+    route: {}
+    # Pass-through AlertmanagerConfig spec.receivers (each: name + *Configs list).
+    receivers: []
+    # Optional pass-through spec.inhibitRules.
+    inhibitRules: []
 
 # Optional Bitnami PostgreSQL dependency. This is development-only because the
 # subchart does not include PostGIS; production should use an external


### PR DESCRIPTION
## Summary

The chart's `PrometheusRule` shipped only kube-state-metrics infrastructure alerts (zero available replicas, crash-looping) and there was no receiver surface at all, so deployments were blind to request availability/error-rate and — critically — to the GeoServices **200-with-`{error}`** envelopes. GeoServices returns HTTP 200 with an `{error}` body for Esri-client compatibility, so those failures are invisible to load-balancer 5xx metrics.

This adds an opt-in application SLO rule group plus an Alertmanager receiver surface, consistent with the cross-repo SLO theme in honua-devops / honua-iac / honua-server.

## Changes Made

- Add `metrics.prometheusRule.slo` (default enabled when the rule is rendered): a `honua.slo` group with request-availability, combined error-rate, multi-window burn-rate (fast/medium/slow), and a dedicated `HonuaGeoServicesInBandErrorRateHigh` alert.
- Every ratio sums the whole `honua_request_error_total` counter, which the server increments with `in_band="true"` for the 200-with-`{error}` envelopes, so the in-band error class is always counted; the in-band alert surfaces it directly. Thresholds/windows mirror the honua-devops SLO rules and are fully overridable. `slo.metricSelector` scopes the counters to the release.
- Add `metrics.alertmanagerConfig`: a pass-through receiver/route surface rendered as a `monitoring.coreos.com/v1alpha1` AlertmanagerConfig (does not deploy Alertmanager). SLO alerts carry `severity`/`route` labels a route can match on.
- Add a centralized `validations.yaml` guard requiring at least one receiver when `alertmanagerConfig.enabled`.
- Extend `values.schema.json` (new `slo`/`alertmanagerConfig` structural validation + `honuaBurnRateTier` definition), `values.yaml`, and `README.md`.
- Extend the `observability` CI fixture and CI assertions (in-band alert, burn-rate alert, AlertmanagerConfig render, opt-in negative checks, receiver-guard negative check).

All resources remain disabled by default, so the chart still installs on clusters without the Prometheus Operator.

## Breaking Changes

None. New values are additive and opt-in; existing `metrics.prometheusRule.enabled` behavior is unchanged except that enabling it now also renders the `honua.slo` group (which can be turned off with `metrics.prometheusRule.slo.enabled: false`).

## Testing

- `helm lint honua -f honua/ci-values/base.yaml` and the dev/stage overlays pass.
- `helm template` renders the PrometheusRule (infra + SLO groups), AlertmanagerConfig, and honors all opt-in toggles.
- Negative: `alertmanagerConfig.enabled` without receivers fails render; base.yaml renders no monitoring CRDs.
